### PR TITLE
Add GWO training addon combining eLearning and surveys

### DIFF
--- a/gwo_training/__init__.py
+++ b/gwo_training/__init__.py
@@ -1,0 +1,3 @@
+from . import models
+from . import controllers
+from . import wizard

--- a/gwo_training/__manifest__.py
+++ b/gwo_training/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    'name': 'GWO Training Suite',
+    'version': '18.0.1.0.0',
+    'category': 'Website/eLearning',
+    'summary': 'Combined GWO refresher training with eLearning and survey-based assessments.',
+    'depends': ['website', 'website_slides', 'survey'],
+    'data': [
+        'security/ir.model.access.csv',
+        'security/rules.xml',
+        'views/gwo_course_views.xml',
+        'views/gwo_content_views.xml',
+        'views/gwo_reporting_views.xml',
+        'report/certificate_qweb.xml',
+        'data/survey_quizzes.xml',
+        'data/seed_gwo.xml',
+    ],
+    'demo': [],
+    'application': True,
+    'license': 'LGPL-3',
+}

--- a/gwo_training/controllers/__init__.py
+++ b/gwo_training/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal

--- a/gwo_training/controllers/portal.py
+++ b/gwo_training/controllers/portal.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from odoo import http
+from odoo.http import request
+
+
+class GwoTrainingPortal(http.Controller):
+
+    @http.route('/gwo/course/<int:course_id>/final_exam/start', type='http', auth='user', website=True)
+    def start_final_exam(self, course_id, **kwargs):
+        course = request.env['gwo.course'].sudo().browse(course_id)
+        if not course.exists() or not course.final_exam_id:
+            return request.not_found()
+        user = request.env.user
+        enrollment = request.env['gwo.enrollment'].sudo().search([
+            ('course_id', '=', course.id),
+            ('user_id', '=', user.id),
+        ], limit=1)
+        if not enrollment:
+            if user.has_group('gwo_training.group_gwo_training_instructor') or user.has_group('gwo_training.group_gwo_training_manager'):
+                enrollment = request.env['gwo.enrollment'].sudo().create({
+                    'course_id': course.id,
+                    'user_id': user.id,
+                })
+            else:
+                return request.render('website.403')
+        survey = course.final_exam_id.sudo()
+        user_input = survey._create_answer(
+            partner=enrollment.user_id.partner_id,
+            email=enrollment.user_id.email or enrollment.user_id.partner_id.email,
+        )
+        user_input.write({
+            'state': 'in_progress',
+            'gwo_enrollment_id': enrollment.id,
+        })
+        url = '/survey/start/%s?token=%s' % (survey.id, user_input.token)
+        return request.redirect(url)

--- a/gwo_training/data/seed_gwo.xml
+++ b/gwo_training/data/seed_gwo.xml
@@ -1,0 +1,182 @@
+<odoo>
+    <data noupdate="0">
+        <record id="slide_channel_gwo_bstr" model="slide.channel">
+            <field name="name">Working at Heights Refresher + Manual Handling Refresher (GWO BSTR)</field>
+            <field name="description">Dieser kombinierte Kurs vermittelt aktuelle Sicherheitsanforderungen für Arbeiten in der Höhe und ergonomische Handhabung gemäß GWO BSTR Standard.</field>
+            <field name="is_published" eval="True"/>
+            <field name="allow_comment" eval="True"/>
+            <field name="enroll" eval="'invite'"/>
+        </record>
+
+        <record id="gwo_course_bstr" model="gwo.course">
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="gwo_domain">offshore</field>
+            <field name="category">refresher</field>
+            <field name="validity_months">24</field>
+            <field name="passing_score">80</field>
+            <field name="final_exam_id" ref="gwo_training.survey_wah_mh_final"/>
+            <field name="certificate_template_id" ref="gwo_training.action_report_gwo_certificate"/>
+        </record>
+
+        <!-- Slides -->
+        <record id="slide_intro" model="slide.slide">
+            <field name="name">Kursintro</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">infographic</field>
+            <field name="description">Überblick über Lernziele: PSA-Kompetenz, Risikowahrnehmung, Rettungsbereitschaft und ergonomisches Verhalten.</field>
+            <field name="sequence">1</field>
+        </record>
+        <record id="slide_ppe" model="slide.slide">
+            <field name="name">PPE Grundlagen</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">document</field>
+            <field name="description">Aktualisierte Anforderungen an Auffanggurte, Verbindungsmittel und Rettungssysteme.</field>
+            <field name="sequence">2</field>
+        </record>
+        <record id="slide_hazards" model="slide.slide">
+            <field name="name">Gefährdungen &amp; Risikoerkennung</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">infographic</field>
+            <field name="description">Fokus auf dynamische Risikobeurteilung, Wetter, Anlagenstatus und Kommunikation.</field>
+            <field name="sequence">3</field>
+        </record>
+        <record id="slide_anchor" model="slide.slide">
+            <field name="name">Anschlagpunkte &amp; Steigschutz</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">infographic</field>
+            <field name="description">Visualisierung geeigneter Anschlagpunkte, Mindestlasten und Leiternutzung.</field>
+            <field name="sequence">4</field>
+        </record>
+        <record id="slide_rescue" model="slide.slide">
+            <field name="name">Rettungsgrundlagen</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">presentation</field>
+            <field name="description">Szenarienbasierte Rettungspläne, Rollenverteilung und Nachsorge.</field>
+            <field name="sequence">5</field>
+        </record>
+        <record id="slide_dropped" model="slide.slide">
+            <field name="name">Dropped Objects vermeiden</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">infographic</field>
+            <field name="description">Barrierestrategien, Werkzeugmanagement und Kontrollzonen.</field>
+            <field name="sequence">6</field>
+        </record>
+        <record id="slide_ergonomics" model="slide.slide">
+            <field name="name">Ergonomie &amp; Positive Manual Handling</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">presentation</field>
+            <field name="description">Sichere Körperhaltung, koordiniertes Team-Lifting, Nutzung technischer Hilfen.</field>
+            <field name="sequence">7</field>
+        </record>
+        <record id="slide_planning" model="slide.slide">
+            <field name="name">Planung &amp; Alternativen zum Heben</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">webpage</field>
+            <field name="url">https://globalwindsafety.org/manual-handling-alternatives</field>
+            <field name="description">Planungsprinzipien für Lastreduktion, Wegeführung und Hilfsmittel.</field>
+            <field name="sequence">8</field>
+        </record>
+        <record id="slide_quiz" model="slide.slide">
+            <field name="name">Zwischen-Quiz WaH + MH</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">quiz</field>
+            <field name="survey_id" ref="gwo_training.survey_wah_mh_quiz"/>
+            <field name="sequence">9</field>
+        </record>
+        <record id="slide_video" model="slide.slide">
+            <field name="name">Praxisvideo: Doppelhakentechnik</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">video</field>
+            <field name="url">https://example.com/videos/gwo-twin-lanyards</field>
+            <field name="description">Demonstration des sicheren Einsatzes von Doppelhaken in einer Gondel.</field>
+            <field name="sequence">10</field>
+        </record>
+        <record id="slide_final_intro" model="slide.slide">
+            <field name="name">Abschlusstest Hinweis</field>
+            <field name="channel_id" ref="slide_channel_gwo_bstr"/>
+            <field name="slide_type">infographic</field>
+            <field name="description">Hinweise zur Prüfungsvorbereitung, Mindestscore 80 %, Zeitplanung 45 Minuten.</field>
+            <field name="sequence">11</field>
+        </record>
+
+        <!-- Content delegation -->
+        <record id="gwo_content_intro" model="gwo.content">
+            <field name="slide_id" ref="slide_intro"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">text</field>
+            <field name="estimated_minutes">5</field>
+            <field name="is_mandatory" eval="True"/>
+        </record>
+        <record id="gwo_content_ppe" model="gwo.content">
+            <field name="slide_id" ref="slide_ppe"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">presentation</field>
+            <field name="estimated_minutes">10</field>
+            <field name="is_mandatory" eval="True"/>
+        </record>
+        <record id="gwo_content_hazards" model="gwo.content">
+            <field name="slide_id" ref="slide_hazards"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">text</field>
+            <field name="estimated_minutes">10</field>
+            <field name="is_mandatory" eval="True"/>
+        </record>
+        <record id="gwo_content_anchor" model="gwo.content">
+            <field name="slide_id" ref="slide_anchor"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">image</field>
+            <field name="estimated_minutes">10</field>
+            <field name="is_mandatory" eval="True"/>
+        </record>
+        <record id="gwo_content_rescue" model="gwo.content">
+            <field name="slide_id" ref="slide_rescue"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">presentation</field>
+            <field name="estimated_minutes">15</field>
+            <field name="is_mandatory" eval="True"/>
+        </record>
+        <record id="gwo_content_dropped" model="gwo.content">
+            <field name="slide_id" ref="slide_dropped"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">text</field>
+            <field name="estimated_minutes">8</field>
+            <field name="is_mandatory" eval="True"/>
+        </record>
+        <record id="gwo_content_ergonomics" model="gwo.content">
+            <field name="slide_id" ref="slide_ergonomics"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">presentation</field>
+            <field name="estimated_minutes">12</field>
+            <field name="is_mandatory" eval="True"/>
+        </record>
+        <record id="gwo_content_planning" model="gwo.content">
+            <field name="slide_id" ref="slide_planning"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">link</field>
+            <field name="estimated_minutes">8</field>
+            <field name="is_mandatory" eval="True"/>
+        </record>
+        <record id="gwo_content_quiz" model="gwo.content">
+            <field name="slide_id" ref="slide_quiz"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">quiz</field>
+            <field name="estimated_minutes">10</field>
+            <field name="related_quiz_id" ref="gwo_training.survey_wah_mh_quiz"/>
+            <field name="is_mandatory" eval="True"/>
+        </record>
+        <record id="gwo_content_video" model="gwo.content">
+            <field name="slide_id" ref="slide_video"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">video</field>
+            <field name="estimated_minutes">6</field>
+            <field name="is_mandatory" eval="True"/>
+        </record>
+        <record id="gwo_content_final_intro" model="gwo.content">
+            <field name="slide_id" ref="slide_final_intro"/>
+            <field name="course_id" ref="gwo_course_bstr"/>
+            <field name="content_type">text</field>
+            <field name="estimated_minutes">4</field>
+            <field name="is_mandatory" eval="False"/>
+        </record>
+    </data>
+</odoo>

--- a/gwo_training/data/survey_quizzes.xml
+++ b/gwo_training/data/survey_quizzes.xml
@@ -1,0 +1,280 @@
+<odoo>
+    <data noupdate="0">
+        <record id="survey_wah_mh_quiz" model="survey.survey">
+            <field name="title">GWO WaH + MH Knowledge Check</field>
+            <field name="description">Formative quiz covering safe working at height and manual handling checkpoints.</field>
+            <field name="scoring_type">with_scoring</field>
+            <field name="access_mode">token</field>
+            <field name="question_time_limit">0</field>
+            <field name="quizz_mode">on</field>
+            <field name="quizz_score_min">80</field>
+        </record>
+
+        <record id="survey_wah_mh_final" model="survey.survey">
+            <field name="title">GWO BSTR WaH + MH Final Exam</field>
+            <field name="description">Summative assessment covering working at heights refresher and positive manual handling behaviours.</field>
+            <field name="scoring_type">with_scoring</field>
+            <field name="quizz_mode">on</field>
+            <field name="access_mode">token</field>
+            <field name="quizz_score_min">80</field>
+        </record>
+
+        <!-- Quiz questions -->
+        <record id="survey_question_precheck" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_quiz"/>
+            <field name="title">Was ist vor Steigbeginn zu prüfen?</field>
+            <field name="question_type">simple_choice</field>
+            <field name="is_required" eval="True"/>
+        </record>
+        <record id="survey_question_precheck_answer1" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_precheck"/>
+            <field name="value">PPE Sichtprüfung vollständig</field>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_question_precheck_answer2" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_precheck"/>
+            <field name="value">Nur ob der Helm sitzt</field>
+        </record>
+        <record id="survey_question_precheck_answer3" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_precheck"/>
+            <field name="value">Ob das Werkzeug sortiert ist</field>
+        </record>
+
+        <record id="survey_question_anchor" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_quiz"/>
+            <field name="title">Mindestanforderung an Anschlagpunkte?</field>
+            <field name="question_type">simple_choice</field>
+            <field name="is_required" eval="True"/>
+        </record>
+        <record id="survey_question_anchor_answer1" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_anchor"/>
+            <field name="value">Mindestens 12 kN je Benutzer</field>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_question_anchor_answer2" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_anchor"/>
+            <field name="value">Beliebiger Leitersprossenhalter</field>
+        </record>
+
+        <record id="survey_question_dropped" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_quiz"/>
+            <field name="title">Welche Maßnahmen helfen, Dropped Objects zu vermeiden?</field>
+            <field name="question_type">multiple_choice</field>
+            <field name="is_required" eval="True"/>
+        </record>
+        <record id="survey_question_dropped_answer1" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_dropped"/>
+            <field name="value">Werkzeugleinen nutzen</field>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_question_dropped_answer2" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_dropped"/>
+            <field name="value">Arbeitsbereich sichern</field>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_question_dropped_answer3" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_dropped"/>
+            <field name="value">Werkzeug lose in Taschen stecken</field>
+        </record>
+
+        <record id="survey_question_rescue" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_quiz"/>
+            <field name="title">Ordne die Schritte einer Grundrettung.</field>
+            <field name="question_type">ranking</field>
+            <field name="is_required" eval="True"/>
+        </record>
+        <record id="survey_question_rescue_answer1" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_rescue"/>
+            <field name="value">Absperren</field>
+            <field name="sequence">1</field>
+        </record>
+        <record id="survey_question_rescue_answer2" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_rescue"/>
+            <field name="value">Eigenschutz</field>
+            <field name="sequence">2</field>
+        </record>
+        <record id="survey_question_rescue_answer3" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_rescue"/>
+            <field name="value">Kommunikation</field>
+            <field name="sequence">3</field>
+        </record>
+        <record id="survey_question_rescue_answer4" model="survey.question.answer">
+            <field name="question_id" ref="survey_question_rescue"/>
+            <field name="value">Sicherung &amp; Rettung</field>
+            <field name="sequence">4</field>
+        </record>
+
+        <record id="survey_question_mh_signs" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_quiz"/>
+            <field name="title">Nenne zwei Anzeichen muskuloskelettaler Belastung.</field>
+            <field name="question_type">textbox</field>
+            <field name="is_required" eval="True"/>
+        </record>
+
+        <!-- Final exam representative subset of questions -->
+        <record id="survey_final_q1" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_final"/>
+            <field name="title">Welche täglichen Kontrollen gehören zur Sichtprüfung der persönlichen Schutzausrüstung?</field>
+            <field name="question_type">multiple_choice</field>
+            <field name="is_required" eval="True"/>
+            <field name="topic">wah</field>
+        </record>
+        <record id="survey_final_q1_a1" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q1"/>
+            <field name="value">Karabiner und Verbindungsmittel auf Verschleiß prüfen</field>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_final_q1_a2" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q1"/>
+            <field name="value">Farbe der PSA an Tageslicht angleichen</field>
+        </record>
+        <record id="survey_final_q1_a3" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q1"/>
+            <field name="value">Körperliche Fitness dokumentieren</field>
+        </record>
+
+        <record id="survey_final_q2" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_final"/>
+            <field name="title">Welche Technik ist geeignet, um eine 25 kg-Nabe über 10 m zu bewegen?</field>
+            <field name="question_type">simple_choice</field>
+            <field name="topic">mh</field>
+        </record>
+        <record id="survey_final_q2_a1" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q2"/>
+            <field name="value">Team-Lift mit synchronem Schritt und klarer Kommunikation</field>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_final_q2_a2" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q2"/>
+            <field name="value">Alleiniger Rückenlift mit gebeugten Knien</field>
+        </record>
+
+        <record id="survey_final_q3" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_final"/>
+            <field name="title">Ordne die Phasen einer Rettung aus der Höhe.</field>
+            <field name="question_type">ranking</field>
+            <field name="topic">wah</field>
+        </record>
+        <record id="survey_final_q3_a1" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q3"/>
+            <field name="value">Lage sichern</field>
+            <field name="sequence">1</field>
+        </record>
+        <record id="survey_final_q3_a2" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q3"/>
+            <field name="value">Notruf &amp; Kommunikation</field>
+            <field name="sequence">2</field>
+        </record>
+        <record id="survey_final_q3_a3" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q3"/>
+            <field name="value">Zugang schaffen</field>
+            <field name="sequence">3</field>
+        </record>
+        <record id="survey_final_q3_a4" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q3"/>
+            <field name="value">Rettung durchführen</field>
+            <field name="sequence">4</field>
+        </record>
+
+        <record id="survey_final_q4" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_final"/>
+            <field name="title">Welche Aussagen zur ergonomischen Arbeitshaltung treffen zu?</field>
+            <field name="question_type">multiple_choice</field>
+            <field name="topic">mh</field>
+        </record>
+        <record id="survey_final_q4_a1" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q4"/>
+            <field name="value">Last nah am Körper halten</field>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_final_q4_a2" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q4"/>
+            <field name="value">Rotationsbewegungen vermeiden</field>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_final_q4_a3" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q4"/>
+            <field name="value">Kraft aus dem Rücken statt aus den Beinen</field>
+        </record>
+
+        <record id="survey_final_q5" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_final"/>
+            <field name="title">Beschreibe zwei Maßnahmen zur Rettungsbereitschaft.</field>
+            <field name="question_type">textbox</field>
+            <field name="topic">wah</field>
+        </record>
+
+        <record id="survey_final_q6" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_final"/>
+            <field name="title">Welche Dokumentation ist nach einer Rettung zwingend zu erstellen?</field>
+            <field name="question_type">simple_choice</field>
+            <field name="topic">wah</field>
+        </record>
+        <record id="survey_final_q6_a1" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q6"/>
+            <field name="value">Einsatzbericht mit Lessons Learned</field>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_final_q6_a2" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q6"/>
+            <field name="value">Nur eine SMS an den Vorgesetzten</field>
+        </record>
+
+        <record id="survey_final_q7" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_final"/>
+            <field name="title">Welches Hilfsmittel reduziert das Risiko bei häufigem Heben?</field>
+            <field name="question_type">simple_choice</field>
+            <field name="topic">mh</field>
+        </record>
+        <record id="survey_final_q7_a1" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q7"/>
+            <field name="value">Verstellbare Hebezeuge oder Rollwagen verwenden</field>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_final_q7_a2" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q7"/>
+            <field name="value">Zusätzliches Gewicht anbringen</field>
+        </record>
+
+        <record id="survey_final_q8" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_final"/>
+            <field name="title">Bewerte die passende Absturzsicherung für Arbeiten an der Nabe.</field>
+            <field name="question_type">matrix</field>
+            <field name="matrix_subtype">simple_choice</field>
+            <field name="topic">wah</field>
+        </record>
+        <record id="survey_final_q8_row1" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q8"/>
+            <field name="value">Kurzzeitiger Aufenthalt</field>
+        </record>
+        <record id="survey_final_q8_row2" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q8"/>
+            <field name="value">Lange Wartungstätigkeit</field>
+        </record>
+        <record id="survey_final_q8_col1" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q8"/>
+            <field name="value">Temporäres Seitenschutzsystem</field>
+            <field name="matrix_is_column" eval="True"/>
+            <field name="is_correct" eval="True"/>
+        </record>
+        <record id="survey_final_q8_col2" model="survey.question.answer">
+            <field name="question_id" ref="survey_final_q8"/>
+            <field name="value">Persönliches Auffangsystem</field>
+            <field name="matrix_is_column" eval="True"/>
+        </record>
+
+        <record id="survey_final_q9" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_final"/>
+            <field name="title">Welche Kommunikation ist beim Team-Lift entscheidend?</field>
+            <field name="question_type">textbox</field>
+            <field name="topic">mh</field>
+        </record>
+
+        <record id="survey_final_q10" model="survey.question">
+            <field name="survey_id" ref="survey_wah_mh_final"/>
+            <field name="title">Nenne zwei Kontrollen vor Nutzung eines Steigschutzsystems.</field>
+            <field name="question_type">textbox</field>
+            <field name="topic">wah</field>
+        </record>
+    </data>
+</odoo>

--- a/gwo_training/i18n/de.po
+++ b/gwo_training/i18n/de.po
@@ -1,0 +1,12 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: gwo_training 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2024-01-01 00:00+0000\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Translation placeholder

--- a/gwo_training/i18n/en.po
+++ b/gwo_training/i18n/en.po
@@ -1,0 +1,12 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: gwo_training 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2024-01-01 00:00+0000\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Translation placeholder

--- a/gwo_training/models/__init__.py
+++ b/gwo_training/models/__init__.py
@@ -1,0 +1,5 @@
+from . import survey_inherit
+from . import gwo_course
+from . import gwo_content
+from . import gwo_enrollment
+from . import gwo_result

--- a/gwo_training/models/gwo_content.py
+++ b/gwo_training/models/gwo_content.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class GwoContent(models.Model):
+    _name = 'gwo.content'
+    _description = 'GWO Course Content'
+    _inherits = {'slide.slide': 'slide_id'}
+    _order = 'sequence, id'
+
+    slide_id = fields.Many2one('slide.slide', required=True, ondelete='cascade')
+    course_id = fields.Many2one('gwo.course', required=True, ondelete='cascade')
+    content_type = fields.Selection([
+        ('text', 'Text'),
+        ('image', 'Image'),
+        ('presentation', 'Presentation'),
+        ('link', 'External Link'),
+        ('video', 'Video'),
+        ('quiz', 'Quiz'),
+    ], default='text', required=True)
+    estimated_minutes = fields.Integer(default=5)
+    is_mandatory = fields.Boolean(default=True)
+    related_quiz_id = fields.Many2one('survey.survey', string='Related Quiz')
+
+    @staticmethod
+    def _update_slide_channel(records):
+        for record in records:
+            if record.course_id and record.slide_id.channel_id != record.course_id.channel_id:
+                record.slide_id.channel_id = record.course_id.channel_id
+
+    @staticmethod
+    def _ensure_related_quiz(records):
+        for record in records.filtered(lambda r: r.content_type == 'quiz' and not r.related_quiz_id):
+            record.related_quiz_id = record.slide_id.survey_id
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        self._update_slide_channel(records)
+        self._ensure_related_quiz(records)
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        self._update_slide_channel(self)
+        self._ensure_related_quiz(self)
+        return res
+
+    def action_open_related_quiz(self):
+        self.ensure_one()
+        if self.related_quiz_id:
+            return {
+                'type': 'ir.actions.act_window',
+                'name': self.related_quiz_id.title,
+                'res_model': 'survey.survey',
+                'res_id': self.related_quiz_id.id,
+                'view_mode': 'form',
+            }
+        return False

--- a/gwo_training/models/gwo_course.py
+++ b/gwo_training/models/gwo_course.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class GwoCourse(models.Model):
+    _name = 'gwo.course'
+    _description = 'GWO Training Course'
+    _inherits = {'slide.channel': 'channel_id'}
+
+    channel_id = fields.Many2one('slide.channel', required=True, ondelete='cascade', string='Learning Channel')
+    gwo_domain = fields.Selection([
+        ('onshore', 'Onshore'),
+        ('offshore', 'Offshore'),
+    ], default='onshore', required=True, string='GWO Domain')
+    category = fields.Selection([
+        ('refresher', 'Refresher'),
+        ('initial', 'Initial'),
+    ], default='refresher', required=True)
+    validity_months = fields.Integer(default=24, string='Certificate Validity (months)')
+    passing_score = fields.Float(default=80.0, string='Passing Score (%)')
+    final_exam_id = fields.Many2one('survey.survey', string='Final Exam Survey', help='Final certification assessment.')
+    total_duration_min = fields.Integer(compute='_compute_total_duration', store=True)
+    certificate_template_id = fields.Many2one(
+        'ir.actions.report',
+        string='Certificate Report',
+        domain="[('model', '=', 'gwo.enrollment')]",
+    )
+    content_ids = fields.One2many('gwo.content', 'course_id', string='Course Contents')
+    enrollment_ids = fields.One2many('gwo.enrollment', 'course_id', string='Enrollments')
+    instructor_ids = fields.Many2many('res.users', 'gwo_course_instructor_rel', 'course_id', 'user_id', string='Instructors')
+    manager_id = fields.Many2one('res.users', string='Course Manager', default=lambda self: self.env.user)
+    best_pass_rate = fields.Float(compute='_compute_metrics', string='Pass Rate (%)')
+    average_score = fields.Float(compute='_compute_metrics', string='Average Score (%)')
+    mandatory_content_count = fields.Integer(compute='_compute_content_counts', string='Mandatory Items')
+    completion_count = fields.Integer(compute='_compute_metrics', string='Completed Enrollments')
+
+    def action_view_enrollments(self):
+        self.ensure_one()
+        return {
+            'name': _('Enrollments'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'gwo.enrollment',
+            'view_mode': 'tree,form',
+            'domain': [('course_id', '=', self.id)],
+            'context': {'default_course_id': self.id},
+        }
+
+    def action_view_results(self):
+        self.ensure_one()
+        return {
+            'name': _('Learner Results'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'gwo.user.result',
+            'view_mode': 'tree,form,pivot,graph',
+            'domain': [('enrollment_id.course_id', '=', self.id)],
+        }
+
+    def action_launch_final_exam(self):
+        self.ensure_one()
+        if not self.final_exam_id:
+            raise UserError(_('No final exam configured for this course.'))
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Launch Final Exam'),
+            'res_model': 'gwo.launch.exam.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {
+                'default_course_id': self.id,
+                'default_final_exam_id': self.final_exam_id.id,
+            },
+        }
+
+    @api.depends('content_ids.estimated_minutes')
+    def _compute_total_duration(self):
+        for course in self:
+            course.total_duration_min = sum(course.content_ids.mapped('estimated_minutes'))
+
+    @api.depends('enrollment_ids.final_exam_score', 'enrollment_ids.passed')
+    def _compute_metrics(self):
+        for course in self:
+            enrollments = course.enrollment_ids
+            completed = enrollments.filtered(lambda e: e.final_exam_score)
+            passed = enrollments.filtered(lambda e: e.passed)
+            course.completion_count = len(completed)
+            course.best_pass_rate = (len(passed) / len(enrollments) * 100.0) if enrollments else 0.0
+            if completed:
+                course.average_score = sum(completed.mapped('final_exam_score')) / len(completed)
+            else:
+                course.average_score = 0.0
+
+    @api.depends('content_ids.is_mandatory')
+    def _compute_content_counts(self):
+        for course in self:
+            course.mandatory_content_count = len(course.content_ids.filtered('is_mandatory'))
+
+    def compute_progress(self, user):
+        self.ensure_one()
+        enrollment = self.enrollment_ids.filtered(lambda e: e.user_id == user)
+        if enrollment:
+            enrollment._compute_progress_pct()
+        return enrollment.progress_pct if enrollment else 0.0
+
+    def action_mark_slide_done(self, user, slide):
+        self.ensure_one()
+        content = self.content_ids.filtered(lambda c: c.slide_id == slide)
+        if not content:
+            return False
+        enrollment = self.enrollment_ids.filtered(lambda e: e.user_id == user)
+        if not enrollment:
+            return False
+        result = self.env['gwo.user.result'].search([
+            ('enrollment_id', '=', enrollment.id),
+            ('content_id', '=', content.id),
+        ], limit=1)
+        if not result:
+            result = self.env['gwo.user.result'].create({
+                'enrollment_id': enrollment.id,
+                'content_id': content.id,
+            })
+        result.write({
+            'status': 'done',
+            'score': result.score or 0.0,
+        })
+        enrollment._compute_progress_pct()
+        enrollment.write({'last_activity': fields.Datetime.now()})
+        return True
+
+    def _cron_update_progress(self):
+        # Placeholder for scheduled recalculation hooks.
+        for course in self.search([]):
+            for enrollment in course.enrollment_ids:
+                enrollment._compute_progress_pct()

--- a/gwo_training/models/gwo_enrollment.py
+++ b/gwo_training/models/gwo_enrollment.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class GwoEnrollment(models.Model):
+    _name = 'gwo.enrollment'
+    _description = 'GWO Enrollment'
+    _sql_constraints = [
+        ('gwo_enrollment_unique_user_course', 'unique(user_id, course_id)', 'A learner can only enroll once in a course.'),
+    ]
+
+    user_id = fields.Many2one('res.users', required=True, ondelete='cascade')
+    course_id = fields.Many2one('gwo.course', required=True, ondelete='cascade')
+    progress_pct = fields.Float(compute='_compute_progress_pct', store=True)
+    passed = fields.Boolean(compute='_compute_passed', store=True)
+    final_exam_score = fields.Float(default=0.0)
+    last_activity = fields.Datetime(default=fields.Datetime.now)
+    result_ids = fields.One2many('gwo.user.result', 'enrollment_id', string='Content Results')
+
+    @api.depends('result_ids.status', 'course_id.content_ids.is_mandatory')
+    def _compute_progress_pct(self):
+        for enrollment in self:
+            mandatory = enrollment.course_id.content_ids.filtered('is_mandatory')
+            if not mandatory:
+                enrollment.progress_pct = 0.0
+                continue
+            completed = enrollment.result_ids.filtered(lambda r: r.content_id in mandatory and r.status == 'done')
+            enrollment.progress_pct = (len(completed) / len(mandatory)) * 100.0
+
+    @api.depends('final_exam_score', 'course_id.passing_score')
+    def _compute_passed(self):
+        for enrollment in self:
+            enrollment.passed = bool(enrollment.final_exam_score and enrollment.final_exam_score >= enrollment.course_id.passing_score)
+
+    def action_launch_final_exam(self):
+        self.ensure_one()
+        return self.course_id.action_launch_final_exam()
+
+    def mark_final_score(self, score):
+        self.ensure_one()
+        self.write({
+            'final_exam_score': score,
+            'last_activity': fields.Datetime.now(),
+        })

--- a/gwo_training/models/gwo_result.py
+++ b/gwo_training/models/gwo_result.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class GwoUserResult(models.Model):
+    _name = 'gwo.user.result'
+    _description = 'GWO Learner Result'
+    _order = 'create_date desc'
+    _sql_constraints = [
+        ('unique_result_per_content', 'unique(enrollment_id, content_id)', 'Result already exists for this content.'),
+    ]
+
+    enrollment_id = fields.Many2one('gwo.enrollment', required=True, ondelete='cascade')
+    content_id = fields.Many2one('gwo.content', required=True, ondelete='cascade')
+    status = fields.Selection([
+        ('todo', 'To Do'),
+        ('in_progress', 'In Progress'),
+        ('done', 'Done'),
+    ], default='todo')
+    score = fields.Float(default=0.0)
+    survey_input_id = fields.Many2one('survey.user_input', string='Survey Attempt')
+
+    @api.onchange('survey_input_id')
+    def _onchange_survey_input_id(self):
+        for record in self:
+            if record.survey_input_id:
+                record.score = record.survey_input_id.quizz_score
+                if record.survey_input_id.state == 'done':
+                    record.status = 'done'
+
+    def mark_from_survey(self, survey_input):
+        self.ensure_one()
+        self.write({
+            'survey_input_id': survey_input.id,
+            'score': survey_input.quizz_score,
+            'status': 'done' if survey_input.state == 'done' else self.status,
+        })
+        self.enrollment_id._compute_progress_pct()
+        self.enrollment_id.write({'last_activity': fields.Datetime.now()})

--- a/gwo_training/models/survey_inherit.py
+++ b/gwo_training/models/survey_inherit.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class SurveyUserInput(models.Model):
+    _inherit = 'survey.user_input'
+
+    gwo_enrollment_id = fields.Many2one('gwo.enrollment', string='GWO Enrollment')
+
+    def write(self, vals):
+        previous_states = {record.id: record.state for record in self}
+        res = super().write(vals)
+        for record in self:
+            state_before = previous_states.get(record.id)
+            if record.state == 'done' and state_before != 'done':
+                record._gwo_sync_results()
+        return res
+
+    def _gwo_sync_results(self):
+        self.ensure_one()
+        enrollment = self.gwo_enrollment_id
+        if not enrollment:
+            enrollment = self.env['gwo.enrollment'].search([
+                ('user_id', '=', self.user_id.id if self.user_id else False),
+                ('course_id.final_exam_id', '=', self.survey_id.id),
+            ], limit=1)
+        if not enrollment:
+            return
+        if enrollment.course_id.final_exam_id == self.survey_id:
+            enrollment.mark_final_score(self.quizz_score)
+            if enrollment.course_id.certificate_template_id:
+                enrollment.course_id.certificate_template_id._render_qweb_pdf(enrollment.ids)
+            return
+        content = self.env['gwo.content'].search([
+            ('course_id', '=', enrollment.course_id.id),
+            ('related_quiz_id', '=', self.survey_id.id),
+        ], limit=1)
+        if not content:
+            return
+        result = self.env['gwo.user.result'].search([
+            ('enrollment_id', '=', enrollment.id),
+            ('content_id', '=', content.id),
+        ], limit=1)
+        if not result:
+            result = self.env['gwo.user.result'].create({
+                'enrollment_id': enrollment.id,
+                'content_id': content.id,
+            })
+        result.mark_from_survey(self)
+
+
+class SurveyUserInputLine(models.Model):
+    _inherit = 'survey.user_input_line'
+
+    @api.depends('answer_score')
+    def _compute_gwo_problematic(self):
+        for line in self:
+            line.gwo_is_problematic = line.answer_score < 1
+
+    gwo_is_problematic = fields.Boolean(compute='_compute_gwo_problematic', string='Flagged in GWO Reports')

--- a/gwo_training/readme/USAGE.md
+++ b/gwo_training/readme/USAGE.md
@@ -1,0 +1,21 @@
+# GWO Training Suite Usage
+
+## Installation
+1. Install required dependencies: `website`, `website_slides`, `survey`.
+2. Add the `gwo_training` module to your addons path and update the app list.
+3. Install the module from Apps.
+
+## Initial Data
+After installation the course *Working at Heights Refresher + Manual Handling Refresher (GWO BSTR)*, the formative quiz and the final exam surveys are available. Invite learners via the linked eLearning channel.
+
+## Roles
+- **GWO Training Manager**: Full control, can configure courses, manage instructors, review analytics.
+- **GWO Training Instructor**: Maintain course content, manage participant progress, launch exams.
+- **GWO Training User**: Access enrolled courses, attempt quizzes and exams, download certificates.
+
+## Workflow
+1. Assign learners to the seeded course or create new courses via **GWO Training &gt; Courses**.
+2. Add mixed content (text, video, links, presentations) through the Contents tab.
+3. Use the smart button to review enrollments and analytics.
+4. Launch the final exam from the course form or via the portal route `/gwo/course/&lt;course_id&gt;/final_exam/start`.
+5. Upon completion, final scores update automatically and certificates can be printed from the enrollment record.

--- a/gwo_training/report/certificate_qweb.xml
+++ b/gwo_training/report/certificate_qweb.xml
@@ -1,0 +1,35 @@
+<odoo>
+    <data>
+        <template id="report_gwo_certificate">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <h2 class="text-center">GWO Training Certificate</h2>
+                    <p class="text-center">
+                        <strong t-esc="doc.user_id.partner_id.name"/> has successfully completed the refresher training
+                        <strong t-esc="doc.course_id.name"/>.
+                    </p>
+                    <p>
+                        Final score: <span t-esc="'%.2f%%' % doc.final_exam_score"/>.<br/>
+                        Training domain: <span t-esc="dict(doc.course_id._fields['gwo_domain'].selection).get(doc.course_id.gwo_domain)"/>.<br/>
+                        Certificate valid until:
+                        <t t-set="expiry_base" t-value="doc.last_activity.date() if doc.last_activity else fields.Date.today()"/>
+                        <t t-set="expiry" t-value="fields.Date.add(expiry_base, months=doc.course_id.validity_months)"/>
+                        <span t-esc="expiry"/>
+                    </p>
+                    <p>
+                        Generated on <span t-esc="fields.Date.today()"/>.
+                    </p>
+                </div>
+            </t>
+        </template>
+
+        <report
+            id="action_report_gwo_certificate"
+            string="GWO Certificate"
+            model="gwo.enrollment"
+            report_type="qweb-pdf"
+            name="gwo_training.report_gwo_certificate"
+            file="gwo_training.report_gwo_certificate"
+        />
+    </data>
+</odoo>

--- a/gwo_training/security/ir.model.access.csv
+++ b/gwo_training/security/ir.model.access.csv
@@ -1,0 +1,15 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_gwo_course_manager,gwo.course manager access,model_gwo_course,gwo_training.group_gwo_training_manager,1,1,1,1
+access_gwo_course_instructor,gwo.course instructor access,model_gwo_course,gwo_training.group_gwo_training_instructor,1,1,1,0
+access_gwo_course_user,gwo.course user access,model_gwo_course,gwo_training.group_gwo_training_user,1,0,0,0
+access_gwo_content_manager,gwo.content manager access,model_gwo_content,gwo_training.group_gwo_training_manager,1,1,1,1
+access_gwo_content_instructor,gwo.content instructor access,model_gwo_content,gwo_training.group_gwo_training_instructor,1,1,1,0
+access_gwo_content_user,gwo.content user access,model_gwo_content,gwo_training.group_gwo_training_user,1,0,0,0
+access_gwo_enrollment_manager,gwo.enrollment manager access,model_gwo_enrollment,gwo_training.group_gwo_training_manager,1,1,1,1
+access_gwo_enrollment_instructor,gwo.enrollment instructor access,model_gwo_enrollment,gwo_training.group_gwo_training_instructor,1,1,0,0
+access_gwo_enrollment_user,gwo.enrollment user access,model_gwo_enrollment,gwo_training.group_gwo_training_user,1,1,0,0
+access_gwo_user_result_manager,gwo.user.result manager access,model_gwo_user_result,gwo_training.group_gwo_training_manager,1,1,1,1
+access_gwo_user_result_instructor,gwo.user.result instructor access,model_gwo_user_result,gwo_training.group_gwo_training_instructor,1,1,0,0
+access_gwo_user_result_user,gwo.user.result user access,model_gwo_user_result,gwo_training.group_gwo_training_user,1,0,0,0
+access_gwo_launch_exam_wizard,gwo.launch.exam.wizard access,model_gwo_launch_exam_wizard,gwo_training.group_gwo_training_instructor,1,1,1,1
+access_gwo_launch_exam_wizard_manager,gwo.launch.exam.wizard manager access,model_gwo_launch_exam_wizard,gwo_training.group_gwo_training_manager,1,1,1,1

--- a/gwo_training/security/rules.xml
+++ b/gwo_training/security/rules.xml
@@ -1,0 +1,59 @@
+<odoo>
+    <data noupdate="1">
+        <record id="group_gwo_training_user" model="res.groups">
+            <field name="name">GWO Training User</field>
+            <field name="category_id" ref="base.module_category_website"/>
+        </record>
+        <record id="group_gwo_training_manager" model="res.groups">
+            <field name="name">GWO Training Manager</field>
+            <field name="category_id" ref="base.module_category_website"/>
+        </record>
+        <record id="group_gwo_training_instructor" model="res.groups">
+            <field name="name">GWO Training Instructor</field>
+            <field name="implied_ids" eval="[(4, ref('gwo_training.group_gwo_training_user'))]"/>
+            <field name="category_id" ref="base.module_category_website"/>
+        </record>
+
+        <record id="rule_gwo_course_user" model="ir.rule">
+            <field name="name">GWO Course User Access</field>
+            <field name="model_id" ref="model_gwo_course"/>
+            <field name="domain_force">['|', ('channel_id.is_published', '=', True), ('enrollment_ids.user_id', '=', user.id)]</field>
+            <field name="groups" eval="[(4, ref('gwo_training.group_gwo_training_user'))]"/>
+        </record>
+
+        <record id="rule_gwo_enrollment_user" model="ir.rule">
+            <field name="name">GWO Enrollment User Access</field>
+            <field name="model_id" ref="model_gwo_enrollment"/>
+            <field name="domain_force">[('user_id', '=', user.id)]</field>
+            <field name="groups" eval="[(4, ref('gwo_training.group_gwo_training_user'))]"/>
+        </record>
+
+        <record id="rule_gwo_user_result_user" model="ir.rule">
+            <field name="name">GWO User Result Access</field>
+            <field name="model_id" ref="model_gwo_user_result"/>
+            <field name="domain_force">[('enrollment_id.user_id', '=', user.id)]</field>
+            <field name="groups" eval="[(4, ref('gwo_training.group_gwo_training_user'))]"/>
+        </record>
+
+        <record id="rule_gwo_course_instructor" model="ir.rule">
+            <field name="name">GWO Course Instructor Access</field>
+            <field name="model_id" ref="model_gwo_course"/>
+            <field name="domain_force">['|', ('instructor_ids', 'in', user.id), ('manager_id', '=', user.id)]</field>
+            <field name="groups" eval="[(4, ref('gwo_training.group_gwo_training_instructor'))]"/>
+        </record>
+
+        <record id="rule_gwo_enrollment_instructor" model="ir.rule">
+            <field name="name">GWO Enrollment Instructor Access</field>
+            <field name="model_id" ref="model_gwo_enrollment"/>
+            <field name="domain_force">[('course_id.instructor_ids', 'in', user.id)]</field>
+            <field name="groups" eval="[(4, ref('gwo_training.group_gwo_training_instructor'))]"/>
+        </record>
+
+        <record id="rule_gwo_user_result_instructor" model="ir.rule">
+            <field name="name">GWO User Result Instructor Access</field>
+            <field name="model_id" ref="model_gwo_user_result"/>
+            <field name="domain_force">[('enrollment_id.course_id.instructor_ids', 'in', user.id)]</field>
+            <field name="groups" eval="[(4, ref('gwo_training.group_gwo_training_instructor'))]"/>
+        </record>
+    </data>
+</odoo>

--- a/gwo_training/tests/test_course.py
+++ b/gwo_training/tests/test_course.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestGwoCourse(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.course = self.env.ref('gwo_training.gwo_course_bstr')
+        self.user = self.env['res.users'].create({
+            'name': 'Learner Test',
+            'login': 'learner@test.example',
+            'email': 'learner@test.example',
+        })
+        self.enrollment = self.env['gwo.enrollment'].create({
+            'user_id': self.user.id,
+            'course_id': self.course.id,
+        })
+
+    def test_progress_computation(self):
+        mandatory_contents = self.course.content_ids.filtered('is_mandatory')
+        self.assertTrue(mandatory_contents, 'Mandatory contents should exist')
+        first_content = mandatory_contents[0]
+        result = self.env['gwo.user.result'].create({
+            'enrollment_id': self.enrollment.id,
+            'content_id': first_content.id,
+            'status': 'done',
+        })
+        self.enrollment._compute_progress_pct()
+        self.assertGreater(self.enrollment.progress_pct, 0.0)
+
+    def test_final_exam_score_updates_passed(self):
+        self.enrollment.mark_final_score(85.0)
+        self.assertTrue(self.enrollment.passed)
+        self.assertEqual(self.enrollment.final_exam_score, 85.0)

--- a/gwo_training/views/gwo_content_views.xml
+++ b/gwo_training/views/gwo_content_views.xml
@@ -1,0 +1,163 @@
+<odoo>
+    <data>
+        <record id="view_gwo_content_tree" model="ir.ui.view">
+            <field name="name">gwo.content.tree</field>
+            <field name="model">gwo.content</field>
+            <field name="arch" type="xml">
+                <tree string="Course Contents">
+                    <field name="course_id"/>
+                    <field name="name"/>
+                    <field name="content_type"/>
+                    <field name="is_mandatory"/>
+                    <field name="estimated_minutes"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_gwo_content_form" model="ir.ui.view">
+            <field name="name">gwo.content.form</field>
+            <field name="model">gwo.content</field>
+            <field name="arch" type="xml">
+                <form string="Content">
+                    <sheet>
+                        <group>
+                            <field name="course_id"/>
+                            <field name="name"/>
+                            <field name="content_type"/>
+                            <field name="related_quiz_id"/>
+                            <field name="is_mandatory"/>
+                            <field name="estimated_minutes"/>
+                        </group>
+                        <group>
+                            <field name="description" widget="html"/>
+                            <field name="url" attrs="{'invisible': [('content_type', 'not in', ['link', 'video'])]}"/>
+                            <field name="datas" filename="name" attrs="{'invisible': [('content_type', 'not in', ['presentation', 'image'])]}"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_gwo_content" model="ir.actions.act_window">
+            <field name="name">Contents</field>
+            <field name="res_model">gwo.content</field>
+            <field name="view_mode">tree,form</field>
+            <field name="context">{'default_is_mandatory': True}</field>
+        </record>
+
+        <record id="view_gwo_enrollment_tree" model="ir.ui.view">
+            <field name="name">gwo.enrollment.tree</field>
+            <field name="model">gwo.enrollment</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="user_id"/>
+                    <field name="course_id"/>
+                    <field name="progress_pct" widget="percentpie"/>
+                    <field name="final_exam_score"/>
+                    <field name="passed"/>
+                    <field name="last_activity"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_gwo_enrollment_form" model="ir.ui.view">
+            <field name="name">gwo.enrollment.form</field>
+            <field name="model">gwo.enrollment</field>
+            <field name="arch" type="xml">
+                <form string="Enrollment">
+                    <sheet>
+                        <group>
+                            <field name="user_id"/>
+                            <field name="course_id"/>
+                            <field name="progress_pct" widget="percentpie" readonly="1"/>
+                            <field name="passed" readonly="1"/>
+                            <field name="final_exam_score" readonly="1"/>
+                        </group>
+                        <group>
+                            <field name="last_activity" readonly="1"/>
+                        </group>
+                        <notebook>
+                            <page string="Results">
+                                <field name="result_ids">
+                                    <tree editable="bottom">
+                                        <field name="content_id"/>
+                                        <field name="status"/>
+                                        <field name="score"/>
+                                        <field name="survey_input_id"/>
+                                    </tree>
+                                </field>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_gwo_enrollment" model="ir.actions.act_window">
+            <field name="name">Enrollments</field>
+            <field name="res_model">gwo.enrollment</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+        <record id="view_gwo_user_result_tree" model="ir.ui.view">
+            <field name="name">gwo.user.result.tree</field>
+            <field name="model">gwo.user.result</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="enrollment_id"/>
+                    <field name="content_id"/>
+                    <field name="status"/>
+                    <field name="score"/>
+                    <field name="survey_input_id"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_gwo_user_result_form" model="ir.ui.view">
+            <field name="name">gwo.user.result.form</field>
+            <field name="model">gwo.user.result</field>
+            <field name="arch" type="xml">
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="enrollment_id"/>
+                            <field name="content_id"/>
+                            <field name="status"/>
+                            <field name="score"/>
+                            <field name="survey_input_id"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_gwo_user_result" model="ir.actions.act_window">
+            <field name="name">Results</field>
+            <field name="res_model">gwo.user.result</field>
+            <field name="view_mode">tree,form,pivot,graph</field>
+        </record>
+
+        <record id="view_launch_exam_wizard" model="ir.ui.view">
+            <field name="name">gwo.launch.exam.wizard.form</field>
+            <field name="model">gwo.launch.exam.wizard</field>
+            <field name="arch" type="xml">
+                <form string="Start Final Exam">
+                    <group>
+                        <field name="course_id" readonly="1"/>
+                        <field name="enrollment_id"/>
+                        <field name="final_exam_id" readonly="1"/>
+                        <field name="launch_mode"/>
+                    </group>
+                    <footer>
+                        <button name="action_launch" string="Start" type="object" class="btn-primary"/>
+                        <button special="cancel" string="Cancel" class="btn-secondary"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <menuitem id="menu_gwo_content" name="Contents" parent="menu_gwo_training_root" action="action_gwo_content" sequence="20" groups="gwo_training.group_gwo_training_manager,gwo_training.group_gwo_training_instructor"/>
+        <menuitem id="menu_gwo_enrollment" name="Participants" parent="menu_gwo_training_root" action="action_gwo_enrollment" sequence="30" groups="gwo_training.group_gwo_training_manager,gwo_training.group_gwo_training_instructor"/>
+        <menuitem id="menu_gwo_results" name="Results" parent="menu_gwo_training_root" action="action_gwo_user_result" sequence="40" groups="gwo_training.group_gwo_training_manager,gwo_training.group_gwo_training_instructor"/>
+    </data>
+</odoo>

--- a/gwo_training/views/gwo_course_views.xml
+++ b/gwo_training/views/gwo_course_views.xml
@@ -1,0 +1,154 @@
+<odoo>
+    <data>
+        <record id="view_gwo_course_tree" model="ir.ui.view">
+            <field name="name">gwo.course.tree</field>
+            <field name="model">gwo.course</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="name"/>
+                    <field name="gwo_domain"/>
+                    <field name="category"/>
+                    <field name="total_duration_min"/>
+                    <field name="best_pass_rate" widget="percentpie"/>
+                    <field name="average_score"/>
+                    <field name="mandatory_content_count"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_gwo_course_form" model="ir.ui.view">
+            <field name="name">gwo.course.form</field>
+            <field name="model">gwo.course</field>
+            <field name="arch" type="xml">
+                <form string="GWO Course" create="true">
+                    <header>
+                        <button name="action_launch_final_exam" type="object" string="Launch Final Exam" class="oe_highlight" attrs="{'invisible': [('final_exam_id', '=', False)]}"/>
+                        <button name="action_view_enrollments" type="object" string="View Enrollments"/>
+                        <button name="action_view_results" type="object" string="View Results"/>
+                    </header>
+                    <sheet>
+                        <div class="oe_button_box" name="button_box">
+                            <button class="oe_stat_button" type="object" name="action_view_enrollments">
+                                <div class="o_stat_info">
+                                    <span class="o_stat_value" field="completion_count"/>
+                                    <span class="o_stat_text">Completed</span>
+                                </div>
+                            </button>
+                            <button class="oe_stat_button" type="object" name="action_view_results">
+                                <div class="o_stat_info">
+                                    <span class="o_stat_value" field="best_pass_rate" widget="percentpie"/>
+                                    <span class="o_stat_text">Pass Rate</span>
+                                </div>
+                            </button>
+                        </div>
+                        <group>
+                            <group>
+                                <field name="name"/>
+                                <field name="gwo_domain"/>
+                                <field name="category"/>
+                                <field name="passing_score"/>
+                                <field name="final_exam_id"/>
+                            </group>
+                            <group>
+                                <field name="manager_id"/>
+                                <field name="instructor_ids" widget="many2many_tags"/>
+                                <field name="validity_months"/>
+                                <field name="certificate_template_id"/>
+                                <field name="total_duration_min" readonly="1"/>
+                            </group>
+                        </group>
+                        <notebook>
+                            <page string="Overview">
+                                <field name="description" widget="html"/>
+                            </page>
+                            <page string="Contents">
+                                <field name="content_ids" context="{'default_course_id': active_id}">
+                                    <tree editable="bottom">
+                                        <field name="sequence"/>
+                                        <field name="name"/>
+                                        <field name="content_type"/>
+                                        <field name="is_mandatory"/>
+                                        <field name="estimated_minutes"/>
+                                        <field name="related_quiz_id" optional="show"/>
+                                    </tree>
+                                    <form>
+                                        <sheet>
+                                            <group>
+                                                <field name="name"/>
+                                                <field name="content_type"/>
+                                                <field name="slide_category"/>
+                                                <field name="is_mandatory"/>
+                                                <field name="estimated_minutes"/>
+                                                <field name="related_quiz_id"/>
+                                            </group>
+                                            <group>
+                                                <field name="description" widget="html"/>
+                                                <field name="datas" filename="name" invisible="1"/>
+                                            </group>
+                                        </sheet>
+                                    </form>
+                                </field>
+                            </page>
+                            <page string="Participants">
+                                <field name="enrollment_ids">
+                                    <tree>
+                                        <field name="user_id"/>
+                                        <field name="progress_pct" widget="percentpie"/>
+                                        <field name="final_exam_score"/>
+                                        <field name="passed"/>
+                                        <field name="last_activity"/>
+                                    </tree>
+                                </field>
+                            </page>
+                            <page string="Analytics">
+                                <group>
+                                    <field name="best_pass_rate" widget="gauge" readonly="1"/>
+                                    <field name="average_score" readonly="1"/>
+                                </group>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="view_gwo_course_kanban" model="ir.ui.view">
+            <field name="name">gwo.course.kanban</field>
+            <field name="model">gwo.course</field>
+            <field name="arch" type="xml">
+                <kanban default_group_by="category">
+                    <field name="name"/>
+                    <field name="best_pass_rate"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div class="oe_kanban_card">
+                                <div class="o_kanban_primary_left">
+                                    <strong><field name="name"/></strong>
+                                    <div>
+                                        <span t-field="record.gwo_domain"/>
+                                        <span class="ms-2">⏱️ <t t-esc="record.total_duration_min.value"/> min</span>
+                                    </div>
+                                </div>
+                                <div class="o_kanban_primary_right text-end">
+                                    <div class="badge bg-success">
+                                        <t t-esc="'%s%%' % int(record.best_pass_rate.value or 0)"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>
+            </field>
+        </record>
+
+        <record id="action_gwo_course" model="ir.actions.act_window">
+            <field name="name">GWO Courses</field>
+            <field name="res_model">gwo.course</field>
+            <field name="view_mode">tree,form,kanban</field>
+            <field name="context">{'default_category': 'refresher'}</field>
+        </record>
+
+        <menuitem id="menu_gwo_training_root" name="GWO Training" parent="website.menu_website_configuration" sequence="30" groups="gwo_training.group_gwo_training_manager,gwo_training.group_gwo_training_instructor"/>
+        <menuitem id="menu_gwo_courses" name="Courses" parent="menu_gwo_training_root" action="action_gwo_course" sequence="10"/>
+    </data>
+</odoo>

--- a/gwo_training/views/gwo_reporting_views.xml
+++ b/gwo_training/views/gwo_reporting_views.xml
@@ -1,0 +1,48 @@
+<odoo>
+    <data>
+        <record id="view_gwo_result_pivot" model="ir.ui.view">
+            <field name="name">gwo.user.result.pivot</field>
+            <field name="model">gwo.user.result</field>
+            <field name="arch" type="xml">
+                <pivot string="Learner Progress">
+                    <field name="score" type="measure"/>
+                    <field name="status" type="row"/>
+                    <field name="content_id" type="col"/>
+                    <field name="enrollment_id" type="row"/>
+                </pivot>
+            </field>
+        </record>
+
+        <record id="view_gwo_result_graph" model="ir.ui.view">
+            <field name="name">gwo.user.result.graph</field>
+            <field name="model">gwo.user.result</field>
+            <field name="arch" type="xml">
+                <graph string="Quiz Scores" type="bar">
+                    <field name="score" type="measure"/>
+                    <field name="content_id" type="row"/>
+                </graph>
+            </field>
+        </record>
+
+        <record id="view_gwo_enrollment_graph" model="ir.ui.view">
+            <field name="name">gwo.enrollment.graph</field>
+            <field name="model">gwo.enrollment</field>
+            <field name="arch" type="xml">
+                <graph string="Pass Rate by Month" type="line">
+                    <field name="passed" type="measure" string="Pass Count"/>
+                    <field name="last_activity" interval="month" type="row"/>
+                </graph>
+            </field>
+        </record>
+
+        <record id="action_gwo_reporting_results" model="ir.actions.act_window">
+            <field name="name">Analytics</field>
+            <field name="res_model">gwo.user.result</field>
+            <field name="view_mode">pivot,graph,tree</field>
+            <field name="view_id" ref="view_gwo_result_pivot"/>
+            <field name="context">{'search_default_status_done': 1}</field>
+        </record>
+
+        <menuitem id="menu_gwo_analytics" name="Analytics" parent="menu_gwo_training_root" action="action_gwo_reporting_results" sequence="50" groups="gwo_training.group_gwo_training_manager"/>
+    </data>
+</odoo>

--- a/gwo_training/wizard/__init__.py
+++ b/gwo_training/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import launch_exam_wizard

--- a/gwo_training/wizard/launch_exam_wizard.py
+++ b/gwo_training/wizard/launch_exam_wizard.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class GwoLaunchExamWizard(models.TransientModel):
+    _name = 'gwo.launch.exam.wizard'
+    _description = 'Launch Final Exam Wizard'
+
+    course_id = fields.Many2one('gwo.course', required=True)
+    enrollment_id = fields.Many2one('gwo.enrollment', string='Enrollment')
+    final_exam_id = fields.Many2one('survey.survey', required=True)
+    launch_mode = fields.Selection([
+        ('in_app', 'In-Application'),
+        ('external', 'External Link'),
+    ], default='in_app')
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if not res.get('enrollment_id') and res.get('course_id'):
+            enrollment = self.env['gwo.enrollment'].search([
+                ('course_id', '=', res['course_id']),
+                ('user_id', '=', self.env.user.id),
+            ], limit=1)
+            if enrollment:
+                res['enrollment_id'] = enrollment.id
+        return res
+
+    def action_launch(self):
+        self.ensure_one()
+        if not self.final_exam_id:
+            raise UserError(_('Please select a final exam.'))
+        enrollment = self.enrollment_id
+        if not enrollment:
+            enrollment = self.env['gwo.enrollment'].create({
+                'user_id': self.env.user.id,
+                'course_id': self.course_id.id,
+            })
+            self.enrollment_id = enrollment
+        survey = self.final_exam_id.sudo()
+        user_input = survey._create_answer(
+            partner=enrollment.user_id.partner_id,
+            email=enrollment.user_id.email or enrollment.user_id.partner_id.email,
+        )
+        user_input.write({
+            'state': 'in_progress',
+            'gwo_enrollment_id': enrollment.id,
+        })
+        action = survey.action_start_survey()
+        action.update({
+            'context': {
+                'survey_token': user_input.token,
+                'lang': self.env.user.lang,
+            }
+        })
+        return action


### PR DESCRIPTION
## Summary
- create the new `gwo_training` addon that delegates to eLearning channels and slides while linking surveys for quizzes and exams
- add security, views, controllers, seed data and reporting to manage GWO refresher training with certificates
- provide seed content, quizzes and regression tests for learner progress and exam scoring

## Testing
- python -m compileall gwo_training

------
https://chatgpt.com/codex/tasks/task_e_68e63a2668848321b9f0f6394f5d567b