### PR TITLE
Add Academy Learning e-learning module

### DIFF
--- a/academy_learning/README.rst
+++ b/academy_learning/README.rst
@@ -1,0 +1,25 @@
+Academy Learning
+================
+
+Academy Learning ist eine vollständig neue E-Learning-App für Odoo 18. Sie bündelt Kurserstellung,
+Lektions- und Quizmanagement sowie ein schlankes Teilnehmerportal mit professionellem
+Frontend. Administratoren können komplette Kurse über eine strukturierte ZIP-Datei importieren,
+Teilnehmer teilen sich über einen eindeutigen Link in den Kurs ein und bearbeiten dort Inhalte,
+Quizze sowie Fortschrittsmarkierungen.
+
+Hauptfunktionen
+---------------
+
+* Verwaltung von Kursen, Lektionen, Quizzen und Teilnehmerfortschritt
+* Automatisch generierter eindeutiger Zugangslink pro Kurs
+* Modernes Website-Frontend für Selbstlernkurse inklusive Registrierungsformular
+* Fortschrittskontrolle pro Lektion und automatische Bewertung von Multiple-Choice-Quizzen
+* Wizard zum Hochladen kompletter Kursstrukturen (course.json in ZIP)
+
+Schnellstart
+------------
+
+#. Modul installieren und als Administrator (Gruppe "Academy Learning Administrator") anmelden.
+#. Neuen Kurs anlegen, Inhalte pflegen oder über den Upload-Wizard importieren.
+#. Kurs veröffentlichen und den generierten Link mit Lernenden teilen.
+#. Lernende registrieren sich mit Namen und E-Mail-Adresse und bearbeiten den Kurs vollständig im Browser.

--- a/academy_learning/__init__.py
+++ b/academy_learning/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from . import models
+from . import controllers
+from . import wizards

--- a/academy_learning/__manifest__.py
+++ b/academy_learning/__manifest__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Academy Learning",
+    "summary": "E-Learning platform with course, content, and quiz management",
+    "description": """Academy Learning stellt eine moderne E-Learning-Plattform auf Basis von Odoo 18 bereit.
+Sie ermöglicht das einfache Erstellen, Verwalten und Teilen von Kursen inklusive Lektionen,
+Quizze und Lernfortschritten. Über einen eindeutigen Link können Lernende einem Kurs beitreten
+und den gesamten Content direkt im Web-Frontend absolvieren.""",
+    "author": "",
+    "website": "",
+    "category": "Education",
+    "version": "18.0.1.0.0",
+    "depends": [
+        "base",
+        "web",
+        "website",
+        "portal",
+        "mail",
+    ],
+    "data": [
+        "security/academy_learning_groups.xml",
+        "security/ir.model.access.csv",
+        "data/academy_learning_portal_data.xml",
+        "views/assets.xml",
+        "views/academy_course_views.xml",
+        "views/academy_lesson_views.xml",
+        "views/academy_quiz_views.xml",
+        "views/academy_enrollment_views.xml",
+        "views/academy_wizard_views.xml",
+        "views/academy_menu.xml",
+        "views/academy_website_templates.xml",
+    ],
+    "assets": {
+        "web.assets_frontend": [
+            "academy_learning/static/src/scss/academy_learning.scss",
+        ],
+    },
+    "application": True,
+    "license": "LGPL-3",
+    "icon": "/academy_learning/static/description/icon.svg",
+}

--- a/academy_learning/controllers/__init__.py
+++ b/academy_learning/controllers/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import main

--- a/academy_learning/controllers/main.py
+++ b/academy_learning/controllers/main.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+import json
+import uuid
+
+from werkzeug.exceptions import NotFound
+
+from odoo import http
+from odoo.http import request
+
+
+class AcademyWebsiteController(http.Controller):
+    """Website Controller für Academy Learning."""
+
+    def _get_course(self, token):
+        course = request.env["academy.course"].sudo().search(
+            [("token", "=", token), ("is_published", "=", True)], limit=1
+        )
+        if not course:
+            raise NotFound()
+        return course
+
+    def _get_enrollment(self, course, **kwargs):
+        enrollment_token = kwargs.get("enrollment_token") or request.params.get("enrollment_token")
+        if not enrollment_token:
+            enrollment_token = request.session.get("academy_enrollment_token")
+        if not enrollment_token:
+            return None
+        enrollment = request.env["academy.enrollment"].sudo().search(
+            [("course_id", "=", course.id), ("access_token", "=", enrollment_token)], limit=1
+        )
+        if enrollment:
+            request.session["academy_enrollment_token"] = enrollment.access_token
+        return enrollment
+
+    @http.route("/academy/<string:token>", type="http", auth="public", website=True, sitemap=False)
+    def course_portal(self, token, **kwargs):
+        course = self._get_course(token)
+        enrollment = self._get_enrollment(course, **kwargs)
+        values = {
+            "course": course,
+            "enrollment": enrollment,
+            "lessons": course.lesson_ids.sudo(),
+            "quizzes": course.quiz_ids.sudo(),
+        }
+        return request.render("academy_learning.course_portal", values)
+
+    @http.route(
+        "/academy/<string:token>/register",
+        type="http",
+        auth="public",
+        methods=["POST"],
+        website=True,
+        csrf=True,
+    )
+    def course_register(self, token, **post):
+        course = self._get_course(token)
+        name = post.get("name")
+        email = post.get("email")
+        if not name or not email:
+            return request.redirect(f"/academy/{token}?error=missing")
+
+        partner = request.env["res.partner"].sudo().search([("email", "=", email)], limit=1)
+        if not partner:
+            partner = request.env["res.partner"].sudo().create({"name": name, "email": email})
+        else:
+            partner.sudo().write({"name": name})
+
+        enrollment = request.env["academy.enrollment"].sudo().search(
+            [("course_id", "=", course.id), ("partner_id", "=", partner.id)], limit=1
+        )
+        if not enrollment:
+            enrollment = request.env["academy.enrollment"].sudo().create(
+                {
+                    "course_id": course.id,
+                    "partner_id": partner.id,
+                    "access_token": str(uuid.uuid4()),
+                    "state": "in_progress",
+                }
+            )
+        request.session["academy_enrollment_token"] = enrollment.access_token
+        return request.redirect(f"/academy/{token}?enrollment_token={enrollment.access_token}")
+
+    @http.route(
+        "/academy/<string:token>/lesson/<int:lesson_id>/complete",
+        type="http",
+        auth="public",
+        methods=["POST"],
+        website=True,
+        csrf=True,
+    )
+    def lesson_complete(self, token, lesson_id, **post):
+        course = self._get_course(token)
+        enrollment = self._get_enrollment(course, **post)
+        if not enrollment:
+            return request.redirect(f"/academy/{token}?error=enroll")
+        lesson = request.env["academy.lesson"].sudo().browse(lesson_id)
+        if not lesson or lesson.course_id.id != course.id:
+            raise NotFound()
+        progress_model = request.env["academy.lesson.progress"].sudo()
+        progress = progress_model.search(
+            [("enrollment_id", "=", enrollment.id), ("lesson_id", "=", lesson.id)], limit=1
+        )
+        if not progress:
+            progress_model.create({"enrollment_id": enrollment.id, "lesson_id": lesson.id})
+            enrollment.sudo().recompute_progress()
+        return request.redirect(f"/academy/{token}?enrollment_token={enrollment.access_token}#lesson-{lesson_id}")
+
+    @http.route(
+        "/academy/<string:token>/quiz/<int:quiz_id>/submit",
+        type="http",
+        auth="public",
+        methods=["POST"],
+        website=True,
+        csrf=True,
+    )
+    def quiz_submit(self, token, quiz_id, **post):
+        course = self._get_course(token)
+        enrollment = self._get_enrollment(course, **post)
+        if not enrollment:
+            return request.redirect(f"/academy/{token}?error=enroll")
+        quiz = request.env["academy.quiz"].sudo().browse(quiz_id)
+        if not quiz or quiz.course_id.id != course.id:
+            raise NotFound()
+
+        attempt_count = request.env["academy.quiz.submission"].sudo().search_count(
+            [("enrollment_id", "=", enrollment.id), ("quiz_id", "=", quiz.id)]
+        )
+        if quiz.attempts_allowed and attempt_count >= quiz.attempts_allowed:
+            return request.redirect(f"/academy/{token}?error=attempts")
+
+        questions = quiz.question_ids.sudo()
+        total_questions = len(questions.filtered(lambda q: q.question_type != "text"))
+        score = 0
+        submission_answers = {}
+
+        for question in questions:
+            field_name = f"question_{question.id}"
+            if question.question_type == "text":
+                submission_answers[str(question.id)] = post.get(field_name)
+                continue
+            submitted = (
+                request.httprequest.form.getlist(field_name)
+                if question.question_type == "multiple"
+                else [post.get(field_name)]
+            )
+            submitted = [value for value in submitted if value]
+            submission_answers[str(question.id)] = submitted
+            correct_answers = question.correct_answer_ids()
+            if not correct_answers:
+                continue
+            correct_values = set(str(answer.id) for answer in correct_answers)
+            submitted_values = set(submitted)
+            if question.question_type == "single" and len(submitted_values) == 1 and submitted_values == correct_values:
+                score += 1
+            elif question.question_type == "multiple" and submitted_values == correct_values:
+                score += 1
+
+        percentage = 0.0
+        if total_questions:
+            percentage = (score / total_questions) * 100
+
+        submission = request.env["academy.quiz.submission"].sudo().create(
+            {
+                "name": f"{quiz.name} - {enrollment.partner_id.name}",
+                "enrollment_id": enrollment.id,
+                "quiz_id": quiz.id,
+                "score": percentage,
+                "is_passed": percentage >= quiz.passing_score,
+                "answer_json": json.dumps(submission_answers, ensure_ascii=False),
+            }
+        )
+        enrollment.sudo().write({"quiz_score": percentage})
+        enrollment.sudo().recompute_progress()
+        request.session["academy_last_submission_id"] = submission.id
+        return request.redirect(f"/academy/{token}?enrollment_token={enrollment.access_token}#quiz-{quiz_id}")

--- a/academy_learning/data/academy_learning_portal_data.xml
+++ b/academy_learning/data/academy_learning_portal_data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="base.user_admin" model="res.users">
+            <field name="groups_id" eval="[(4, ref('academy_learning.group_academy_admin'))]"/>
+        </record>
+        <record id="base.user_public" model="res.users">
+            <field name="groups_id" eval="[(4, ref('academy_learning.group_academy_user'))]"/>
+        </record>
+    </data>
+</odoo>

--- a/academy_learning/models/__init__.py
+++ b/academy_learning/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+from . import course
+from . import lesson
+from . import quiz
+from . import enrollment

--- a/academy_learning/models/course.py
+++ b/academy_learning/models/course.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+import uuid
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class AcademyCourse(models.Model):
+    _name = "academy.course"
+    _description = "Academy Learning Course"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "name"
+
+    name = fields.Char(required=True, tracking=True)
+    tagline = fields.Char(help="Kurzer Claim, der im Frontend angezeigt wird.")
+    description = fields.Html(string="Beschreibung", sanitize=True, tracking=True)
+    token = fields.Char(
+        string="Zugangs-Token",
+        required=True,
+        copy=False,
+        default=lambda self: str(uuid.uuid4()),
+        readonly=True,
+    )
+    access_url = fields.Char(string="Zugangslink", compute="_compute_access_url", store=True)
+    lesson_ids = fields.One2many("academy.lesson", "course_id", string="Lektionen")
+    quiz_ids = fields.One2many("academy.quiz", "course_id", string="Quizze")
+    enrollment_ids = fields.One2many("academy.enrollment", "course_id", string="Einschreibungen")
+    lesson_count = fields.Integer(compute="_compute_statistics", store=True)
+    quiz_count = fields.Integer(compute="_compute_statistics", store=True)
+    enrollment_count = fields.Integer(compute="_compute_statistics", store=True)
+    is_published = fields.Boolean(
+        string="Veröffentlicht",
+        help="Nur veröffentlichte Kurse sind über den Link verfügbar.",
+        default=False,
+    )
+    cover_image = fields.Binary(string="Titelbild")
+    color = fields.Integer(default=0)
+
+    _sql_constraints = [
+        ("academy_course_token_unique", "unique(token)", "Der Zugangs-Token muss eindeutig sein."),
+    ]
+
+    def name_get(self):
+        return [(record.id, f"{record.name}") for record in self]
+
+    @api.depends("token")
+    def _compute_access_url(self):
+        base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
+        for course in self:
+            if course.token:
+                course.access_url = f"{base_url}/academy/{course.token}"
+            else:
+                course.access_url = False
+
+    @api.depends("lesson_ids", "quiz_ids", "enrollment_ids")
+    def _compute_statistics(self):
+        for course in self:
+            course.lesson_count = len(course.lesson_ids)
+            course.quiz_count = len(course.quiz_ids)
+            course.enrollment_count = len(course.enrollment_ids)
+
+    def action_generate_new_token(self):
+        for course in self:
+            course.token = str(uuid.uuid4())
+        return True
+
+    def action_open_enrollments(self):
+        self.ensure_one()
+        return {
+            "name": _("Einschreibungen"),
+            "type": "ir.actions.act_window",
+            "res_model": "academy.enrollment",
+            "view_mode": "list,form",
+            "domain": [["course_id", "=", self.id]],
+        }
+
+    def action_open_lessons(self):
+        self.ensure_one()
+        return {
+            "name": _("Lektionen"),
+            "type": "ir.actions.act_window",
+            "res_model": "academy.lesson",
+            "view_mode": "list,form",
+            "domain": [["course_id", "=", self.id]],
+        }
+
+    def action_open_quizzes(self):
+        self.ensure_one()
+        return {
+            "name": _("Quizze"),
+            "type": "ir.actions.act_window",
+            "res_model": "academy.quiz",
+            "view_mode": "list,form",
+            "domain": [["course_id", "=", self.id]],
+        }
+
+    def action_open_upload_wizard(self):
+        self.ensure_one()
+        return {
+            "name": _("Kursinhalt hochladen"),
+            "type": "ir.actions.act_window",
+            "res_model": "academy.course.upload.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_course_id": self.id,
+            },
+        }
+
+    @api.constrains("is_published", "lesson_ids")
+    def _check_publishable(self):
+        for course in self:
+            if course.is_published and not course.lesson_ids:
+                raise ValidationError(
+                    _("Ein Kurs muss mindestens eine Lektion besitzen, bevor er veröffentlicht werden kann."))

--- a/academy_learning/models/enrollment.py
+++ b/academy_learning/models/enrollment.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+from odoo import api, fields, models
+
+
+class AcademyEnrollment(models.Model):
+    _name = "academy.enrollment"
+    _description = "Academy Learning Enrollment"
+    _inherit = ["mail.thread"]
+    _order = "create_date desc"
+
+    name = fields.Char(compute="_compute_name", store=True)
+    course_id = fields.Many2one("academy.course", required=True, ondelete="cascade", tracking=True)
+    partner_id = fields.Many2one("res.partner", required=True, tracking=True)
+    email = fields.Char(related="partner_id.email", store=True)
+    progress = fields.Float(default=0.0, tracking=True)
+    state = fields.Selection(
+        [
+            ("draft", "Neu"),
+            ("in_progress", "In Bearbeitung"),
+            ("done", "Abgeschlossen"),
+        ],
+        default="draft",
+        tracking=True,
+    )
+    quiz_score = fields.Float(string="Letzte Quizbewertung")
+    completed_at = fields.Datetime(string="Abgeschlossen am")
+    access_token = fields.Char(string="Zugangs-Token", copy=False)
+    submission_ids = fields.One2many("academy.quiz.submission", "enrollment_id", string="Quizteilnahmen")
+    lesson_progress_ids = fields.One2many("academy.lesson.progress", "enrollment_id", string="Lektionen")
+
+    _sql_constraints = [
+        (
+            "academy_enrollment_unique",
+            "unique(course_id, partner_id)",
+            "Der Teilnehmer ist bereits für diesen Kurs eingeschrieben.",
+        )
+    ]
+
+    @api.depends("partner_id", "course_id")
+    def _compute_name(self):
+        for enrollment in self:
+            if enrollment.partner_id and enrollment.course_id:
+                enrollment.name = f"{enrollment.partner_id.name} - {enrollment.course_id.name}"
+            else:
+                enrollment.name = False
+
+    def action_mark_in_progress(self):
+        self.write({"state": "in_progress"})
+
+    def action_mark_done(self):
+        self.write({"state": "done", "completed_at": datetime.utcnow()})
+
+    def update_progress(self, value):
+        for enrollment in self:
+            enrollment.progress = max(0.0, min(100.0, value))
+            if enrollment.progress >= 100.0:
+                enrollment.state = "done"
+                enrollment.completed_at = datetime.utcnow()
+            elif enrollment.progress > 0 and enrollment.state == "draft":
+                enrollment.state = "in_progress"
+
+    def recompute_progress(self):
+        for enrollment in self:
+            course = enrollment.course_id
+            total_items = len(course.lesson_ids) + len(course.quiz_ids)
+            completed_lessons = len(enrollment.lesson_progress_ids)
+            passed_quizzes = len(enrollment.submission_ids.filtered("is_passed"))
+            completion = 0.0
+            if total_items:
+                completion = (completed_lessons + passed_quizzes) / total_items * 100
+            enrollment.update_progress(completion)
+
+
+class AcademyQuizSubmission(models.Model):
+    _name = "academy.quiz.submission"
+    _description = "Academy Learning Quiz Submission"
+    _order = "create_date desc"
+
+    name = fields.Char(required=True)
+    enrollment_id = fields.Many2one("academy.enrollment", required=True, ondelete="cascade")
+    quiz_id = fields.Many2one("academy.quiz", required=True, ondelete="cascade")
+    score = fields.Float(string="Ergebnis in %")
+    is_passed = fields.Boolean(string="Bestanden")
+    answer_json = fields.Text(string="Antworten (JSON)")
+
+
+class AcademyLessonProgress(models.Model):
+    _name = "academy.lesson.progress"
+    _description = "Academy Learning Lesson Progress"
+    _order = "completed_at desc"
+
+    enrollment_id = fields.Many2one("academy.enrollment", required=True, ondelete="cascade")
+    lesson_id = fields.Many2one("academy.lesson", required=True, ondelete="cascade")
+    completed_at = fields.Datetime(default=lambda self: fields.Datetime.now())
+
+    _sql_constraints = [
+        ("academy_lesson_progress_unique", "unique(enrollment_id, lesson_id)", "Die Lektion wurde bereits abgeschlossen."),
+    ]

--- a/academy_learning/models/lesson.py
+++ b/academy_learning/models/lesson.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class AcademyLesson(models.Model):
+    _name = "academy.lesson"
+    _description = "Academy Learning Lesson"
+    _order = "sequence, id"
+
+    name = fields.Char(required=True)
+    sequence = fields.Integer(default=10)
+    course_id = fields.Many2one("academy.course", required=True, ondelete="cascade")
+    content = fields.Html(string="Inhalt", sanitize=True)
+    duration_minutes = fields.Integer(string="Dauer (Minuten)")
+    resource_url = fields.Char(string="Ressourcenlink")
+    attachment_ids = fields.Many2many("ir.attachment", string="Anhänge")
+    quiz_ids = fields.Many2many(
+        "academy.quiz",
+        "academy_lesson_quiz_rel",
+        "lesson_id",
+        "quiz_id",
+        string="Zugeordnete Quizze",
+    )
+
+    @api.onchange("course_id")
+    def _onchange_course(self):
+        if self.course_id and not self.name:
+            self.name = f"Lektion {len(self.course_id.lesson_ids) + 1}"

--- a/academy_learning/models/quiz.py
+++ b/academy_learning/models/quiz.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class AcademyQuiz(models.Model):
+    _name = "academy.quiz"
+    _description = "Academy Learning Quiz"
+    _order = "sequence, id"
+
+    name = fields.Char(required=True)
+    course_id = fields.Many2one("academy.course", required=True, ondelete="cascade")
+    sequence = fields.Integer(default=10)
+    introduction = fields.Html(string="Einleitung", sanitize=True)
+    question_ids = fields.One2many("academy.quiz.question", "quiz_id", string="Fragen")
+    passing_score = fields.Integer(
+        string="Bestehensgrenze",
+        default=60,
+        help="Prozentualer Wert, der für das Bestehen des Quiz erreicht werden muss.",
+    )
+    attempts_allowed = fields.Integer(string="Versuche erlaubt", default=0, help="0 bedeutet unbegrenzt")
+
+    @api.constrains("passing_score")
+    def _check_passing_score(self):
+        for quiz in self:
+            if quiz.passing_score < 0 or quiz.passing_score > 100:
+                raise ValidationError(_("Die Bestehensgrenze muss zwischen 0 und 100 liegen."))
+
+
+class AcademyQuizQuestion(models.Model):
+    _name = "academy.quiz.question"
+    _description = "Academy Learning Quiz Question"
+    _order = "sequence, id"
+
+    name = fields.Char(string="Frage", required=True)
+    sequence = fields.Integer(default=10)
+    quiz_id = fields.Many2one("academy.quiz", required=True, ondelete="cascade")
+    question_type = fields.Selection(
+        [
+            ("single", "Single Choice"),
+            ("multiple", "Multiple Choice"),
+            ("text", "Freitext"),
+        ],
+        default="single",
+        required=True,
+    )
+    answer_ids = fields.One2many("academy.quiz.answer", "question_id", string="Antworten")
+    explanation = fields.Text(string="Erklärung")
+
+    def correct_answer_ids(self):
+        return self.answer_ids.filtered("is_correct")
+
+
+class AcademyQuizAnswer(models.Model):
+    _name = "academy.quiz.answer"
+    _description = "Academy Learning Quiz Answer"
+    _order = "sequence, id"
+
+    name = fields.Char(required=True)
+    sequence = fields.Integer(default=10)
+    question_id = fields.Many2one("academy.quiz.question", required=True, ondelete="cascade")
+    is_correct = fields.Boolean(default=False)

--- a/academy_learning/security/academy_learning_groups.xml
+++ b/academy_learning/security/academy_learning_groups.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="group_academy_admin" model="res.groups">
+            <field name="name">Academy Learning Administrator</field>
+            <field name="category_id" ref="base.module_category_education"/>
+        </record>
+
+        <record id="group_academy_user" model="res.groups">
+            <field name="name">Academy Learning User</field>
+            <field name="category_id" ref="base.module_category_education"/>
+        </record>
+    </data>
+</odoo>

--- a/academy_learning/security/ir.model.access.csv
+++ b/academy_learning/security/ir.model.access.csv
@@ -1,0 +1,17 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+academy_course_admin,academy.course admin,model_academy_course,academy_learning.group_academy_admin,1,1,1,1
+academy_course_user,academy.course user,model_academy_course,academy_learning.group_academy_user,1,1,0,0
+academy_lesson_admin,academy.lesson admin,model_academy_lesson,academy_learning.group_academy_admin,1,1,1,1
+academy_lesson_user,academy.lesson user,model_academy_lesson,academy_learning.group_academy_user,1,1,1,0
+academy_quiz_admin,academy.quiz admin,model_academy_quiz,academy_learning.group_academy_admin,1,1,1,1
+academy_quiz_user,academy.quiz user,model_academy_quiz,academy_learning.group_academy_user,1,1,1,0
+academy_question_admin,academy.question admin,model_academy_quiz_question,academy_learning.group_academy_admin,1,1,1,1
+academy_question_user,academy.question user,model_academy_quiz_question,academy_learning.group_academy_user,1,1,1,0
+academy_answer_admin,academy.answer admin,model_academy_quiz_answer,academy_learning.group_academy_admin,1,1,1,1
+academy_answer_user,academy.answer user,model_academy_quiz_answer,academy_learning.group_academy_user,1,1,1,0
+academy_enrollment_admin,academy.enrollment admin,model_academy_enrollment,academy_learning.group_academy_admin,1,1,1,1
+academy_enrollment_user,academy.enrollment user,model_academy_enrollment,academy_learning.group_academy_user,1,1,0,0
+academy_submission_admin,academy.quiz.submission admin,model_academy_quiz_submission,academy_learning.group_academy_admin,1,1,1,1
+academy_submission_user,academy.quiz.submission user,model_academy_quiz_submission,academy_learning.group_academy_user,1,0,0,0
+academy_lesson_progress_admin,academy.lesson.progress admin,model_academy_lesson_progress,academy_learning.group_academy_admin,1,1,1,1
+academy_lesson_progress_user,academy.lesson.progress user,model_academy_lesson_progress,academy_learning.group_academy_user,1,0,0,0

--- a/academy_learning/static/description/icon.svg
+++ b/academy_learning/static/description/icon.svg
@@ -1,0 +1,17 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="92" fill="url(#grad)"/>
+  <g fill="#f8fafc">
+    <path d="M128 160c0-17.7 14.3-32 32-32h192c17.7 0 32 14.3 32 32v32c0 17.7-14.3 32-32 32H160c-17.7 0-32-14.3-32-32v-32z" opacity="0.85"/>
+    <path d="M128 256c0-17.7 14.3-32 32-32h96c17.7 0 32 14.3 32 32v96c0 17.7-14.3 32-32 32h-96c-17.7 0-32-14.3-32-32v-96z"/>
+    <path d="M304 248h48c17.7 0 32 14.3 32 32v72c0 17.7-14.3 32-32 32h-48v-136z" opacity="0.7"/>
+    <path d="M176 120h160v24H176z" opacity="0.3"/>
+  </g>
+  <circle cx="180" cy="308" r="28" fill="#1e293b"/>
+  <path d="M174 300l12 12 24-24" stroke="#f8fafc" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/academy_learning/static/src/scss/academy_learning.scss
+++ b/academy_learning/static/src/scss/academy_learning.scss
@@ -1,0 +1,90 @@
+.o_academy_course_wrapper {
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: #1f2933;
+}
+
+.o_academy_course_hero {
+  background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 60%, #111827 100%);
+  color: #f8fafc;
+  padding: 4rem 0 3rem 0;
+}
+
+.o_academy_course_hero .lead {
+  max-width: 40rem;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.o_academy_course_placeholder {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  padding: 3rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.o_academy_section .card {
+  border: none;
+  border-radius: 18px;
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.08);
+  margin-bottom: 1.5rem;
+}
+
+.o_academy_section .card-body {
+  padding: 2.25rem;
+}
+
+.o_academy_lesson_content {
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.o_academy_lesson_content img {
+  max-width: 100%;
+  border-radius: 12px;
+}
+
+.o_academy_sidebar .card {
+  position: sticky;
+  top: 6rem;
+}
+
+.o_academy_quiz_form .form-check {
+  padding: 0.4rem 0;
+}
+
+.o_academy_quiz_form .form-check-input:checked {
+  background-color: #1d4ed8;
+  border-color: #1d4ed8;
+}
+
+.o_academy_description {
+  max-height: 24rem;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.o_academy_description::-webkit-scrollbar {
+  width: 8px;
+}
+
+.o_academy_description::-webkit-scrollbar-thumb {
+  background: rgba(29, 78, 216, 0.35);
+  border-radius: 4px;
+}
+
+@media (max-width: 991.98px) {
+  .o_academy_course_hero {
+    text-align: center;
+  }
+
+  .o_academy_section .card-body {
+    padding: 1.75rem;
+  }
+
+  .o_academy_sidebar .card {
+    position: static;
+    margin-top: 2rem;
+  }
+}

--- a/academy_learning/views/academy_course_views.xml
+++ b/academy_learning/views/academy_course_views.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="academy_course_view_tree" model="ir.ui.view">
+        <field name="name">academy.course.list</field>
+        <field name="model">academy.course</field>
+        <field name="arch" type="xml">
+            <list string="Kurse" sample="1">
+                <field name="name"/>
+                <field name="tagline"/>
+                <field name="lesson_count" widget="statinfo"/>
+                <field name="quiz_count" widget="statinfo"/>
+                <field name="enrollment_count" widget="statinfo"/>
+                <field name="is_published"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="academy_course_view_form" model="ir.ui.view">
+        <field name="name">academy.course.form</field>
+        <field name="model">academy.course</field>
+        <field name="arch" type="xml">
+            <form string="Kurs">
+                <header>
+                    <button name="action_open_upload_wizard" type="object" string="Content hochladen" class="btn-primary" groups="academy_learning.group_academy_admin"/>
+                    <button name="action_generate_new_token" type="object" string="Neuen Link erstellen" class="btn-secondary"/>
+                    <field name="is_published" widget="boolean_button" options="{'terminology': 'publish'}"/>
+                    <button name="action_open_lessons" type="object" string="Lektionen" class="oe_stat_button">
+                        <div class="o_stat_info">
+                            <span class="o_stat_value">
+                                <field name="lesson_count" widget="statinfo" string="Lektionen"/>
+                            </span>
+                        </div>
+                    </button>
+                    <button name="action_open_quizzes" type="object" string="Quizze" class="oe_stat_button">
+                        <div class="o_stat_info">
+                            <span class="o_stat_value">
+                                <field name="quiz_count" widget="statinfo" string="Quizze"/>
+                            </span>
+                        </div>
+                    </button>
+                    <button name="action_open_enrollments" type="object" string="Einschreibungen" class="oe_stat_button">
+                        <div class="o_stat_info">
+                            <span class="o_stat_value">
+                                <field name="enrollment_count" widget="statinfo" string="Teilnehmer"/>
+                            </span>
+                        </div>
+                    </button>
+                </header>
+                <sheet string="Kursdetails">
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="tagline"/>
+                            <field name="token" readonly="1"/>
+                            <field name="access_url" readonly="1" widget="url"/>
+                        </group>
+                        <group>
+                            <field name="cover_image" widget="image" class="oe_avatar"/>
+                            <field name="color" widget="color"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Beschreibung">
+                            <field name="description" widget="html"/>
+                        </page>
+                        <page string="Lektionen">
+                            <field name="lesson_ids">
+                                <list editable="bottom" string="Lektionen">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="name"/>
+                                    <field name="duration_minutes"/>
+                                    <field name="resource_url"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Quizze">
+                            <field name="quiz_ids">
+                                <list editable="bottom" string="Quizze">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="name"/>
+                                    <field name="passing_score"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Einschreibungen" groups="academy_learning.group_academy_admin">
+                            <field name="enrollment_ids">
+                                <list string="Teilnehmer">
+                                    <field name="partner_id"/>
+                                    <field name="progress"/>
+                                    <field name="state"/>
+                                    <field name="quiz_score"/>
+                                    <field name="completed_at"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="academy_course_view_search" model="ir.ui.view">
+        <field name="name">academy.course.search</field>
+        <field name="model">academy.course</field>
+        <field name="arch" type="xml">
+            <search string="Kurse">
+                <field name="name"/>
+                <field name="tagline"/>
+                <filter name="published" string="Veröffentlicht" domain="[('is_published','=',True)]"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="academy_course_action" model="ir.actions.act_window">
+        <field name="name">Kurse</field>
+        <field name="res_model">academy.course</field>
+        <field name="view_mode">list,form</field>
+        <field name="view_id" ref="academy_course_view_tree"/>
+        <field name="search_view_id" ref="academy_course_view_search"/>
+        <field name="context">{"default_is_published": True}</field>
+    </record>
+</odoo>

--- a/academy_learning/views/academy_enrollment_views.xml
+++ b/academy_learning/views/academy_enrollment_views.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="academy_enrollment_view_tree" model="ir.ui.view">
+        <field name="name">academy.enrollment.list</field>
+        <field name="model">academy.enrollment</field>
+        <field name="arch" type="xml">
+            <list string="Einschreibungen">
+                <field name="create_date"/>
+                <field name="partner_id"/>
+                <field name="course_id"/>
+                <field name="progress" widget="percentpie"/>
+                <field name="state"/>
+                <field name="quiz_score"/>
+                <field name="completed_at"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="academy_enrollment_view_form" model="ir.ui.view">
+        <field name="name">academy.enrollment.form</field>
+        <field name="model">academy.enrollment</field>
+        <field name="arch" type="xml">
+            <form string="Einschreibung">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="partner_id"/>
+                            <field name="course_id"/>
+                            <field name="state"/>
+                            <field name="progress" widget="progressbar"/>
+                            <field name="quiz_score"/>
+                        </group>
+                        <group>
+                            <field name="completed_at"/>
+                            <field name="access_token" readonly="1"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Quizteilnahmen">
+                            <field name="submission_ids">
+                                <list string="Teilnahmen">
+                                    <field name="create_date"/>
+                                    <field name="quiz_id"/>
+                                    <field name="score"/>
+                                    <field name="is_passed"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Lektionen">
+                            <field name="lesson_progress_ids">
+                                <list string="Lektionen">
+                                    <field name="lesson_id"/>
+                                    <field name="completed_at"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="academy_enrollment_view_search" model="ir.ui.view">
+        <field name="name">academy.enrollment.search</field>
+        <field name="model">academy.enrollment</field>
+        <field name="arch" type="xml">
+            <search string="Einschreibungen">
+                <field name="partner_id"/>
+                <field name="course_id"/>
+                <filter name="state_in_progress" string="In Bearbeitung" domain="[('state','=','in_progress')]"/>
+                <filter name="state_done" string="Abgeschlossen" domain="[('state','=','done')]"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="academy_enrollment_action" model="ir.actions.act_window">
+        <field name="name">Einschreibungen</field>
+        <field name="res_model">academy.enrollment</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="academy_enrollment_view_search"/>
+    </record>
+</odoo>

--- a/academy_learning/views/academy_lesson_views.xml
+++ b/academy_learning/views/academy_lesson_views.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="academy_lesson_view_tree" model="ir.ui.view">
+        <field name="name">academy.lesson.list</field>
+        <field name="model">academy.lesson</field>
+        <field name="arch" type="xml">
+            <list string="Lektionen" create="false">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="course_id"/>
+                <field name="duration_minutes"/>
+                <field name="resource_url"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="academy_lesson_view_form" model="ir.ui.view">
+        <field name="name">academy.lesson.form</field>
+        <field name="model">academy.lesson</field>
+        <field name="arch" type="xml">
+            <form string="Lektion">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="course_id"/>
+                            <field name="sequence"/>
+                            <field name="duration_minutes"/>
+                        </group>
+                        <group>
+                            <field name="resource_url"/>
+                            <field name="quiz_ids" widget="many2many_tags"/>
+                            <field name="attachment_ids" widget="many2many_binary" options="{'no_open': True}"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Inhalt">
+                            <field name="content" widget="html"/>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="academy_lesson_view_search" model="ir.ui.view">
+        <field name="name">academy.lesson.search</field>
+        <field name="model">academy.lesson</field>
+        <field name="arch" type="xml">
+            <search string="Lektionen">
+                <field name="name"/>
+                <field name="course_id"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="academy_lesson_action" model="ir.actions.act_window">
+        <field name="name">Lektionen</field>
+        <field name="res_model">academy.lesson</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="academy_lesson_view_search"/>
+    </record>
+</odoo>

--- a/academy_learning/views/academy_menu.xml
+++ b/academy_learning/views/academy_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="academy_learning_root_menu" name="Academy Learning" sequence="10" groups="academy_learning.group_academy_user,academy_learning.group_academy_admin"/>
+
+    <menuitem id="academy_learning_courses_menu" name="Kurse" parent="academy_learning_root_menu" action="academy_learning.academy_course_action" sequence="10"/>
+    <menuitem id="academy_learning_lessons_menu" name="Lektionen" parent="academy_learning_root_menu" action="academy_learning.academy_lesson_action" sequence="20"/>
+    <menuitem id="academy_learning_quizzes_menu" name="Quizze" parent="academy_learning_root_menu" action="academy_learning.academy_quiz_action" sequence="30"/>
+    <menuitem id="academy_learning_enrollments_menu" name="Einschreibungen" parent="academy_learning_root_menu" action="academy_learning.academy_enrollment_action" sequence="40" groups="academy_learning.group_academy_admin"/>
+</odoo>

--- a/academy_learning/views/academy_quiz_views.xml
+++ b/academy_learning/views/academy_quiz_views.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="academy_quiz_view_tree" model="ir.ui.view">
+        <field name="name">academy.quiz.list</field>
+        <field name="model">academy.quiz</field>
+        <field name="arch" type="xml">
+            <list string="Quizze">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="course_id"/>
+                <field name="passing_score"/>
+                <field name="attempts_allowed"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="academy_quiz_view_form" model="ir.ui.view">
+        <field name="name">academy.quiz.form</field>
+        <field name="model">academy.quiz</field>
+        <field name="arch" type="xml">
+            <form string="Quiz">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="course_id"/>
+                            <field name="sequence"/>
+                        </group>
+                        <group>
+                            <field name="passing_score"/>
+                            <field name="attempts_allowed"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Einleitung">
+                            <field name="introduction" widget="html"/>
+                        </page>
+                        <page string="Fragen">
+                            <field name="question_ids">
+                                <list editable="bottom" string="Fragen">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="name"/>
+                                    <field name="question_type"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="academy_quiz_question_view_form" model="ir.ui.view">
+        <field name="name">academy.quiz.question.form</field>
+        <field name="model">academy.quiz.question</field>
+        <field name="arch" type="xml">
+            <form string="Quizfrage">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="quiz_id"/>
+                            <field name="question_type"/>
+                            <field name="sequence"/>
+                        </group>
+                        <group>
+                            <field name="explanation" widget="text"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Antworten">
+                            <field name="answer_ids">
+                                <list editable="bottom" string="Antworten">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="name"/>
+                                    <field name="is_correct" widget="boolean_toggle"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="academy_quiz_question_view_tree" model="ir.ui.view">
+        <field name="name">academy.quiz.question.list</field>
+        <field name="model">academy.quiz.question</field>
+        <field name="arch" type="xml">
+            <list string="Quizfragen">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="quiz_id"/>
+                <field name="question_type"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="academy_quiz_answer_view_tree" model="ir.ui.view">
+        <field name="name">academy.quiz.answer.list</field>
+        <field name="model">academy.quiz.answer</field>
+        <field name="arch" type="xml">
+            <list string="Antworten">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="question_id"/>
+                <field name="is_correct"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="academy_quiz_answer_view_form" model="ir.ui.view">
+        <field name="name">academy.quiz.answer.form</field>
+        <field name="model">academy.quiz.answer</field>
+        <field name="arch" type="xml">
+            <form string="Antwort">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="question_id"/>
+                            <field name="sequence"/>
+                        </group>
+                        <group>
+                            <field name="is_correct"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="academy_quiz_view_search" model="ir.ui.view">
+        <field name="name">academy.quiz.search</field>
+        <field name="model">academy.quiz</field>
+        <field name="arch" type="xml">
+            <search string="Quizze">
+                <field name="name"/>
+                <field name="course_id"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="academy_quiz_action" model="ir.actions.act_window">
+        <field name="name">Quizze</field>
+        <field name="res_model">academy.quiz</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="academy_quiz_view_search"/>
+    </record>
+
+    <record id="academy_question_action" model="ir.actions.act_window">
+        <field name="name">Quizfragen</field>
+        <field name="res_model">academy.quiz.question</field>
+        <field name="view_mode">list,form</field>
+    </record>
+</odoo>

--- a/academy_learning/views/academy_website_templates.xml
+++ b/academy_learning/views/academy_website_templates.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="course_portal" name="Academy Learning Course Portal">
+        <t t-call="website.layout">
+            <div class="o_academy_course_wrapper">
+                <div class="o_academy_course_hero">
+                    <div class="container">
+                        <div class="row align-items-center">
+                            <div class="col-lg-7">
+                                <h1 class="display-4" t-esc="course.name"/>
+                                <p class="lead" t-esc="course.tagline or ''"/>
+                                <t t-if="not enrollment">
+                                    <p class="text-muted">
+                                        Melde dich mit deinem Namen und deiner E-Mail-Adresse an, um direkt mit dem Kurs zu starten.
+                                    </p>
+                                </t>
+                                <t t-else="">
+                                    <p class="text-muted">
+                                        Willkommen zurück, <span t-esc="enrollment.partner_id.name"/>! Dein Fortschritt beträgt
+                                        <strong><span t-esc="int(enrollment.progress)"/>%</strong>.
+                                    </p>
+                                </t>
+                            </div>
+                            <div class="col-lg-5 text-center">
+                                <t t-if="course.cover_image">
+                                    <img t-att-src="'/web/image/academy.course/' + str(course.id) + '/cover_image'" alt="Course cover" class="img-fluid rounded shadow"/>
+                                </t>
+                                <t t-else="">
+                                    <div class="o_academy_course_placeholder">Academy Learning</div>
+                                </t>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="container my-5">
+                    <t t-if="not enrollment">
+                        <div class="row justify-content-center">
+                            <div class="col-lg-6">
+                                <div class="card shadow-sm">
+                                    <div class="card-body p-4">
+                                        <h3 class="card-title">Jetzt anmelden</h3>
+                                        <form t-att-action="'/academy/%s/register' % course.token" method="post" class="o_academy_register">
+                                            <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                            <div class="mb-3">
+                                                <label class="form-label">Name</label>
+                                                <input class="form-control" name="name" required="required" placeholder="Max Mustermann"/>
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">E-Mail</label>
+                                                <input class="form-control" name="email" type="email" required="required" placeholder="max@example.com"/>
+                                            </div>
+                                            <button class="btn btn-primary w-100" type="submit">Kurs starten</button>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+
+                    <t t-if="enrollment">
+                        <div class="row g-4">
+                            <div class="col-lg-8">
+                                <section class="o_academy_section" id="lessons">
+                                    <div class="d-flex align-items-center justify-content-between mb-3">
+                                        <h2 class="h4 mb-0">Lektionen</h2>
+                                        <span class="badge bg-primary rounded-pill" t-esc="len(lessons)"/>
+                                    </div>
+                                    <t t-if="not lessons">
+                                        <p class="text-muted">Für diesen Kurs wurden noch keine Lektionen hinterlegt.</p>
+                                    </t>
+                                    <t t-foreach="lessons" t-as="lesson">
+                                        <div class="card o_academy_lesson" t-att-id="'lesson-%s' % lesson.id">
+                                            <div class="card-body">
+                                                <div class="d-flex justify-content-between align-items-center">
+                                                    <div>
+                                                        <h3 class="h5 mb-1" t-esc="lesson.name"/>
+                                                        <t t-if="lesson.duration_minutes">
+                                                            <span class="badge bg-light text-dark"><i class="fa fa-clock me-1"></i><span t-esc="lesson.duration_minutes"/> Minuten</span>
+                                                        </t>
+                                                    </div>
+                                                    <t t-set="completed" t-value="lesson.id in enrollment.lesson_progress_ids.mapped('lesson_id').ids"/>
+                                                    <form t-att-action="'/academy/%s/lesson/%s/complete' % (course.token, lesson.id)" method="post" class="o_academy_lesson_complete">
+                                                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                                        <input type="hidden" name="enrollment_token" t-att-value="enrollment.access_token"/>
+                                                        <button t-attf-class="btn btn-sm {{'btn-success' if completed else 'btn-outline-primary'}}" t-att-disabled="completed and 'disabled'">
+                                                            <i t-attf-class="fa {{'fa-check' if completed else 'fa-flag'}} me-1"></i>
+                                                            <t t-if="completed">Abgeschlossen</t>
+                                                            <t t-else="">Abschließen</t>
+                                                        </button>
+                                                    </form>
+                                                </div>
+                                                <hr/>
+                                                <div class="o_academy_lesson_content" t-raw="lesson.content or ''"/>
+                                                <t t-if="lesson.resource_url">
+                                                    <a t-att-href="lesson.resource_url" class="btn btn-link mt-3" target="_blank">Zusätzliche Ressourcen</a>
+                                                </t>
+                                            </div>
+                                        </div>
+                                    </t>
+                                </section>
+
+                                <section class="o_academy_section mt-5" id="quizzes">
+                                    <div class="d-flex align-items-center justify-content-between mb-3">
+                                        <h2 class="h4 mb-0">Quizze</h2>
+                                        <span class="badge bg-secondary rounded-pill" t-esc="len(quizzes)"/>
+                                    </div>
+                                    <t t-if="not quizzes">
+                                        <p class="text-muted">Dieser Kurs enthält aktuell keine Quizze.</p>
+                                    </t>
+                                    <t t-foreach="quizzes" t-as="quiz">
+                                        <div class="card o_academy_quiz" t-att-id="'quiz-%s' % quiz.id">
+                                            <div class="card-body">
+                                                <div class="d-flex justify-content-between align-items-center">
+                                                    <div>
+                                                        <h3 class="h5" t-esc="quiz.name"/>
+                                                        <span class="text-muted small">Bestehensgrenze: <t t-esc="quiz.passing_score"/>%</span>
+                                                    </div>
+                                                </div>
+                                                <div class="mt-3" t-raw="quiz.introduction or ''"/>
+                                                <form t-att-action="'/academy/%s/quiz/%s/submit' % (course.token, quiz.id)" method="post" class="o_academy_quiz_form mt-4">
+                                                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                                    <input type="hidden" name="enrollment_token" t-att-value="enrollment.access_token"/>
+                                                    <t t-foreach="quiz.question_ids" t-as="question">
+                                                        <div class="o_academy_question mb-4">
+                                                            <h4 class="h6" t-esc="question.name"/>
+                                                            <t t-if="question.question_type in ('single', 'multiple')">
+                                                                <div class="o_academy_answers">
+                                                                    <t t-foreach="question.answer_ids" t-as="answer">
+                                                                        <div class="form-check">
+                                                                            <t t-if="question.question_type == 'single'">
+                                                                                <input class="form-check-input" type="radio" t-att-name="'question_%s' % question.id" t-att-value="str(answer.id)" t-att-id="'answer-%s' % answer.id"/>
+                                                                            </t>
+                                                                            <t t-else="">
+                                                                                <input class="form-check-input" type="checkbox" t-att-name="'question_%s' % question.id" t-att-value="str(answer.id)" t-att-id="'answer-%s' % answer.id"/>
+                                                                            </t>
+                                                                            <label class="form-check-label" t-att-for="'answer-%s' % answer.id" t-esc="answer.name"/>
+                                                                        </div>
+                                                                    </t>
+                                                                </div>
+                                                            </t>
+                                                            <t t-elif="question.question_type == 'text'">
+                                                                <textarea class="form-control" rows="3" t-att-name="'question_%s' % question.id" placeholder="Deine Antwort"></textarea>
+                                                            </t>
+                                                        </div>
+                                                    </t>
+                                                    <button class="btn btn-outline-secondary" type="submit">Antworten prüfen</button>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    </t>
+                                </section>
+                            </div>
+                            <div class="col-lg-4">
+                                <aside class="o_academy_sidebar">
+                                    <div class="card shadow-sm">
+                                        <div class="card-body">
+                                            <h3 class="h5">Kursüberblick</h3>
+                                            <ul class="list-unstyled small mb-4">
+                                                <li><i class="fa fa-book me-2 text-primary"></i><strong t-esc="len(lessons)"/> Lektionen</li>
+                                                <li><i class="fa fa-question-circle me-2 text-primary"></i><strong t-esc="len(quizzes)"/> Quizze</li>
+                                                <li><i class="fa fa-link me-2 text-primary"></i><a t-att-href="course.access_url" target="_blank">Kurslink teilen</a></li>
+                                            </ul>
+                                            <div class="progress mb-3">
+                                                <div class="progress-bar" role="progressbar" t-att-style="'width: %s%%' % enrollment.progress" t-att-aria-valuenow="enrollment.progress" aria-valuemin="0" aria-valuemax="100">
+                                                    <t t-esc="int(enrollment.progress)"/>%
+                                                </div>
+                                            </div>
+                                            <t t-if="enrollment.quiz_score">
+                                                <div class="alert alert-success" role="alert">
+                                                    Letzte Quizbewertung: <strong><t t-esc="round(enrollment.quiz_score, 2)"/>%</strong>
+                                                </div>
+                                            </t>
+                                            <h4 class="h6 mt-4">Beschreibung</h4>
+                                            <div class="o_academy_description" t-raw="course.description or ''"/>
+                                        </div>
+                                    </div>
+                                </aside>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/academy_learning/views/academy_wizard_views.xml
+++ b/academy_learning/views/academy_wizard_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="academy_course_upload_wizard_view" model="ir.ui.view">
+        <field name="name">academy.course.upload.wizard.form</field>
+        <field name="model">academy.course.upload.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Kursinhalt hochladen">
+                <group>
+                    <field name="course_id" readonly="1"/>
+                    <field name="data_file" filename="filename"/>
+                    <field name="filename" invisible="1"/>
+                    <field name="replace_content"/>
+                    <field name="upload_notes" readonly="1" widget="text"/>
+                </group>
+                <footer>
+                    <button string="Importieren" name="action_upload" type="object" class="btn-primary"/>
+                    <button string="Abbrechen" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/academy_learning/views/assets.xml
+++ b/academy_learning/views/assets.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="academy_learning_frontend_assets" model="ir.asset">
+            <field name="name">Academy Learning Frontend</field>
+            <field name="bundle">web.assets_frontend</field>
+            <field name="sequence">150</field>
+            <field name="active" eval="True"/>
+            <field name="assets" eval="[(0, 0, {'name': 'academy_learning_style', 'path': 'academy_learning/static/src/scss/academy_learning.scss'})]"/>
+        </record>
+    </data>
+</odoo>

--- a/academy_learning/wizards/__init__.py
+++ b/academy_learning/wizards/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import course_upload_wizard

--- a/academy_learning/wizards/course_upload_wizard.py
+++ b/academy_learning/wizards/course_upload_wizard.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+import base64
+import io
+import json
+import zipfile
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class AcademyCourseUploadWizard(models.TransientModel):
+    _name = "academy.course.upload.wizard"
+    _description = "Wizard zum Hochladen kompletter Kursinhalte"
+
+    course_id = fields.Many2one("academy.course", required=True)
+    data_file = fields.Binary(string="ZIP-Datei", required=True)
+    filename = fields.Char(string="Dateiname")
+    replace_content = fields.Boolean(
+        string="Bestehende Inhalte ersetzen",
+        help="Aktivieren, um Lektionen und Quizze des Kurses vor dem Import zu löschen.",
+    )
+    upload_notes = fields.Text(
+        string="Format-Hinweise",
+        default=lambda self: _(
+            "Die ZIP-Datei muss mindestens eine course.json Datei mit folgendem Grundschema enthalten:\n"
+            "{\n  \"course\": {\"name\": \"...\", \"tagline\": \"...\", \"description\": \"...\"},\n"
+            "  \"lessons\": [{\"name\": \"...\", \"content\": \"<p>HTML</p>\"}],\n"
+            "  \"quizzes\": [{\"name\": \"...\", \"questions\": [{\"name\": \"...\", \"answers\": [{\"name\": \"...\", \"is_correct\": true}]}]}]\n}"
+        ),
+        readonly=True,
+    )
+
+    def action_upload(self):
+        self.ensure_one()
+        if not self.data_file:
+            raise UserError(_("Bitte wählen Sie eine ZIP-Datei aus."))
+
+        try:
+            raw = base64.b64decode(self.data_file)
+        except Exception as exc:
+            raise UserError(_("Die Datei konnte nicht dekodiert werden: %s") % exc) from exc
+
+        try:
+            with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+                if "course.json" not in archive.namelist():
+                    raise UserError(_("Die ZIP-Datei enthält keine course.json."))
+                with archive.open("course.json") as json_file:
+                    payload = json.loads(json_file.read().decode("utf-8"))
+        except UserError:
+            raise
+        except Exception as exc:  # pylint: disable=broad-except
+            raise UserError(_("Die Kursdatei konnte nicht gelesen werden: %s") % exc) from exc
+
+        course_vals = payload.get("course", {})
+        lesson_vals = payload.get("lessons", [])
+        quiz_vals = payload.get("quizzes", [])
+
+        course = self.course_id
+        if course_vals:
+            course.write({key: value for key, value in course_vals.items() if key in {"name", "tagline", "description"}})
+
+        if self.replace_content:
+            course.lesson_ids.unlink()
+            course.quiz_ids.unlink()
+
+        lesson_records = []
+        for sequence, data in enumerate(lesson_vals, start=10):
+            lesson_values = {
+                "name": data.get("name") or (_("Lektion %s") % (sequence - 9)),
+                "sequence": data.get("sequence", sequence),
+                "content": data.get("content", ""),
+                "duration_minutes": data.get("duration_minutes", 0),
+                "resource_url": data.get("resource_url"),
+                "course_id": course.id,
+            }
+            lesson_records.append(lesson_values)
+        if lesson_records:
+            self.env["academy.lesson"].create(lesson_records)
+
+        for quiz_data in quiz_vals:
+            quiz = self.env["academy.quiz"].create(
+                {
+                    "name": quiz_data.get("name", _("Neues Quiz")),
+                    "course_id": course.id,
+                    "sequence": quiz_data.get("sequence", 10),
+                    "introduction": quiz_data.get("introduction", ""),
+                    "passing_score": quiz_data.get("passing_score", 60),
+                    "attempts_allowed": quiz_data.get("attempts_allowed", 0),
+                }
+            )
+            for question_sequence, question_data in enumerate(quiz_data.get("questions", []), start=10):
+                question = self.env["academy.quiz.question"].create(
+                    {
+                        "name": question_data.get("name", _("Neue Frage")),
+                        "quiz_id": quiz.id,
+                        "sequence": question_data.get("sequence", question_sequence),
+                        "question_type": question_data.get("question_type", "single"),
+                        "explanation": question_data.get("explanation"),
+                    }
+                )
+                answers = []
+                for answer_sequence, answer_data in enumerate(question_data.get("answers", []), start=10):
+                    answers.append(
+                        {
+                            "name": answer_data.get("name", _("Antwort")),
+                            "question_id": question.id,
+                            "sequence": answer_data.get("sequence", answer_sequence),
+                            "is_correct": bool(answer_data.get("is_correct", False)),
+                        }
+                    )
+                if answers:
+                    self.env["academy.quiz.answer"].create(answers)
+
+        course.invalidate_cache()
+        return {
+            "type": "ir.actions.act_window_close",
+        }


### PR DESCRIPTION
## Summary
- create the new `academy_learning` e-learning application with manifest, security, menus, and styling
- implement models, wizards, and controllers to manage courses, lessons, quizzes, enrollments, and course imports
- add a responsive website experience with registration, lesson completion, and quiz handling for shared course links

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7b12c901883219d58123831cd65de