### PR TITLE
Add Odoo 18 course hub module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# tiktok_agent
-An automated content publishing bot
+# Course Hub Module
+
+Dieses Repository enthält die Odoo 18 App **Course Hub**. Die Erweiterung orientiert sich an den Kernfunktionen von `website_slides` und `survey`, verzichtet jedoch bewusst auf Gamification- und Karma-Mechaniken.
+
+## Funktionsumfang
+
+* Verwaltung von Kursen mit verantwortlichen Personen und Tags
+* Strukturierte Lerninhalte mit kuratierten Templates und hochwertigen Upload-Optionen
+* Teilnehmerverwaltung ausschließlich über das Backend mit detaillierter Fortschrittsanzeige
+* Fortschrittsverfolgung pro Kurs inklusive Durchschnittswerten
+* Vorinstallierte Content-Templates für einen schnellen Start
+
+## Installation
+
+1. Kopiere den Ordner `course_hub` in den `addons`-Pfad deiner Odoo 18 Installation.
+2. Aktualisiere die App-Liste in Odoo und installiere **Course Hub**.
+3. Lege Kurse an, ergänze Inhalte und verwalte Teilnehmende direkt aus dem Backend.
+
+## Hinweise
+
+* Die App verzichtet auf Gamification-Elemente sowie Karma-Regeln.
+* Die Teilnahmeverwaltung erfolgt ausschließlich über das Backend; es werden keine öffentlichen Selbstregistrierungen angeboten.
+* List-Views verwenden den neuen View-Typ `list` anstelle von `tree`, wie in Odoo 18 erforderlich.

--- a/course_hub/__init__.py
+++ b/course_hub/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/course_hub/__manifest__.py
+++ b/course_hub/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Course Hub",
+    "summary": "Create structured courses with curated templates and attendee progress tracking.",
+    "version": "18.0.1.0.0",
+    "category": "Education",
+    "author": "Custom",
+    "website": "https://example.com",
+    "depends": ["base", "mail"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/course_menus.xml",
+        "views/course_views.xml",
+        "data/course_templates.xml",
+    ],
+    "application": True,
+    "license": "LGPL-3",
+}

--- a/course_hub/data/course_templates.xml
+++ b/course_hub/data/course_templates.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="course_tag_starter" model="course.course.tag">
+        <field name="name">Starter</field>
+        <field name="color">3</field>
+    </record>
+    <record id="course_tag_advanced" model="course.course.tag">
+        <field name="name">Fortgeschritten</field>
+        <field name="color">5</field>
+    </record>
+    <record id="course_tag_team" model="course.course.tag">
+        <field name="name">Team</field>
+        <field name="color">8</field>
+    </record>
+
+    <record id="course_template_welcome" model="course.content.template">
+        <field name="name">Willkommen &amp; Erwartungen</field>
+        <field name="content_type">document</field>
+        <field name="default_duration">10</field>
+        <field name="description"><![CDATA[
+            <p>Stellen Sie sich vor, fassen Sie das Ziel des Kurses zusammen und beschreiben Sie, wie die Teilnehmenden Erfolg haben.</p>
+        ]]></field>
+        <field name="is_recommended">True</field>
+        <field name="tag_ids" eval="[(4, ref('course_tag_starter'))]" />
+    </record>
+
+    <record id="course_template_video_deepdive" model="course.content.template">
+        <field name="name">Video Deep Dive</field>
+        <field name="content_type">video</field>
+        <field name="default_duration">20</field>
+        <field name="description"><![CDATA[
+            <p>Nutzen Sie ein hochwertiges Lernvideo und ergänzen Sie es mit einer kurzen Reflexionsfrage.</p>
+        ]]></field>
+        <field name="resource_url">https://example.com/video</field>
+        <field name="tag_ids" eval="[(4, ref('course_tag_advanced'))]" />
+    </record>
+
+    <record id="course_template_quiz_retro" model="course.content.template">
+        <field name="name">Reflexionsfragen</field>
+        <field name="content_type">quiz</field>
+        <field name="default_duration">15</field>
+        <field name="description"><![CDATA[
+            <p>Fragen Sie nach dem wichtigsten Lernerfolg, offenen Fragen und den nächsten Schritten.</p>
+        ]]></field>
+        <field name="is_recommended">True</field>
+        <field name="tag_ids" eval="[(4, ref('course_tag_team'))]" />
+    </record>
+
+    <record id="course_template_template_pack" model="course.content.template">
+        <field name="name">Template Baukasten</field>
+        <field name="content_type">template</field>
+        <field name="description"><![CDATA[
+            <p>Bereitgestellte Dokumentenvorlagen mit Layout-Empfehlungen für Kursmaterialien.</p>
+        ]]></field>
+        <field name="is_recommended">True</field>
+        <field name="tag_ids" eval="[(6, 0, [ref('course_tag_starter'), ref('course_tag_team')])]" />
+    </record>
+</odoo>

--- a/course_hub/models/__init__.py
+++ b/course_hub/models/__init__.py
@@ -1,0 +1,3 @@
+from . import course_course
+from . import course_content
+from . import course_attendee

--- a/course_hub/models/course_attendee.py
+++ b/course_hub/models/course_attendee.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class CourseAttendee(models.Model):
+    _name = "course.attendee"
+    _description = "Course Attendee"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "enrollment_date desc"
+
+    partner_id = fields.Many2one(
+        "res.partner",
+        required=True,
+        ondelete="restrict",
+        tracking=True,
+    )
+    course_id = fields.Many2one(
+        "course.course",
+        required=True,
+        ondelete="cascade",
+        index=True,
+    )
+    enrollment_date = fields.Datetime(
+        default=fields.Datetime.now,
+        tracking=True,
+    )
+    completed_content_ids = fields.Many2many(
+        "course.content",
+        "course_attendee_content_rel",
+        "attendee_id",
+        "content_id",
+        string="Completed Content",
+    )
+    progress = fields.Float(
+        compute="_compute_progress",
+        store=True,
+        digits=(16, 2),
+    )
+    progress_label = fields.Char(compute="_compute_progress", store=True)
+    notes = fields.Text()
+    state = fields.Selection(
+        [
+            ("draft", "Entwurf"),
+            ("in_progress", "Aktiv"),
+            ("done", "Abgeschlossen"),
+        ],
+        default="draft",
+        tracking=True,
+    )
+
+    _sql_constraints = [
+        (
+            "course_attendee_unique",
+            "unique(partner_id, course_id)",
+            "A partner can only attend the same course once.",
+        )
+    ]
+
+    @api.depends("completed_content_ids", "course_id.total_content")
+    def _compute_progress(self):
+        for attendee in self:
+            total = attendee.course_id.total_content
+            completed = len(attendee.completed_content_ids)
+            attendee.progress = total and (completed / total) * 100 or 0.0
+            attendee.progress_label = f"{attendee.progress:.0f}%" if total else "0%"
+            attendee.state = (
+                "done"
+                if attendee.progress >= 100
+                else "in_progress"
+                if attendee.progress > 0
+                else "draft"
+            )
+
+    def action_mark_content_complete(self, content_id):
+        self.ensure_one()
+        content = self.env["course.content"].browse(content_id)
+        if content and content not in self.completed_content_ids:
+            self.completed_content_ids = [(4, content.id)]
+        return True
+
+    def action_reset_progress(self):
+        for attendee in self:
+            attendee.completed_content_ids = [(5, 0, 0)]

--- a/course_hub/models/course_content.py
+++ b/course_hub/models/course_content.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class CourseContent(models.Model):
+    _name = "course.content"
+    _description = "Course Content"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "sequence, id"
+
+    name = fields.Char(required=True, tracking=True)
+    sequence = fields.Integer(default=10)
+    course_id = fields.Many2one(
+        "course.course",
+        required=True,
+        ondelete="cascade",
+        index=True,
+    )
+    content_type = fields.Selection(
+        [
+            ("video", "Video"),
+            ("document", "Dokument"),
+            ("quiz", "Reflexion"),
+            ("template", "Template"),
+            ("url", "Link"),
+        ],
+        required=True,
+        default="document",
+        tracking=True,
+    )
+    description = fields.Html()
+    duration = fields.Integer(
+        help="Estimated duration in minutes for the participant to complete this item.",
+    )
+    attachment_id = fields.Many2one(
+        "ir.attachment",
+        string="Asset",
+        help="Optionally upload a supporting file for this content entry.",
+    )
+    resource_url = fields.Char(string="External Resource")
+    template_id = fields.Many2one(
+        "course.content.template",
+        string="Template",
+        domain="[('content_type', '=', content_type)]",
+    )
+    is_template_based = fields.Boolean(
+        compute="_compute_is_template_based",
+        store=True,
+    )
+    active = fields.Boolean(default=True)
+
+    @api.depends("template_id")
+    def _compute_is_template_based(self):
+        for content in self:
+            content.is_template_based = bool(content.template_id)
+
+    @api.onchange("template_id")
+    def _onchange_template_id(self):
+        for record in self:
+            if record.template_id:
+                template = record.template_id
+                if template.description and not record.description:
+                    record.description = template.description
+                if template.default_duration and not record.duration:
+                    record.duration = template.default_duration
+                if template.attachment_id and not record.attachment_id:
+                    record.attachment_id = template.attachment_id
+                if template.resource_url and not record.resource_url:
+                    record.resource_url = template.resource_url
+
+
+class CourseContentTemplate(models.Model):
+    _name = "course.content.template"
+    _description = "Content Template"
+    _order = "sequence, name"
+
+    name = fields.Char(required=True)
+    sequence = fields.Integer(default=10)
+    content_type = fields.Selection(
+        [
+            ("video", "Video"),
+            ("document", "Dokument"),
+            ("quiz", "Reflexion"),
+            ("template", "Template"),
+            ("url", "Link"),
+        ],
+        required=True,
+        default="document",
+    )
+    description = fields.Html()
+    default_duration = fields.Integer(
+        help="Suggested duration (in minutes) when using this template."
+    )
+    attachment_id = fields.Many2one("ir.attachment", string="Asset")
+    resource_url = fields.Char()
+    tag_ids = fields.Many2many(
+        "course.course.tag",
+        string="Suggested Tags",
+        help="Tags that work well with this template.",
+    )
+    is_recommended = fields.Boolean(default=False)
+
+    _sql_constraints = [
+        ("course_content_template_name_unique", "unique(name)", "Template names must be unique."),
+    ]

--- a/course_hub/models/course_course.py
+++ b/course_hub/models/course_course.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class CourseCourse(models.Model):
+    """High level course configuration with manual attendee management."""
+
+    _name = "course.course"
+    _description = "Course"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+
+    name = fields.Char(required=True, tracking=True)
+    code = fields.Char(tracking=True)
+    description = fields.Html()
+    responsible_id = fields.Many2one(
+        "res.users",
+        string="Course Owner",
+        default=lambda self: self.env.user,
+        tracking=True,
+    )
+    content_ids = fields.One2many("course.content", "course_id", string="Contents")
+    attendee_ids = fields.One2many("course.attendee", "course_id", string="Attendees")
+    active = fields.Boolean(default=True)
+    total_content = fields.Integer(
+        compute="_compute_metrics", store=True, string="Content Items"
+    )
+    total_attendees = fields.Integer(
+        compute="_compute_metrics", store=True, string="Attendees"
+    )
+    avg_progress = fields.Float(
+        compute="_compute_avg_progress",
+        string="Average Progress",
+        digits=(16, 2),
+        help="Average of the completion percentage of all attendees.",
+    )
+    allow_template_upload = fields.Boolean(
+        string="Enable Curated Templates",
+        default=True,
+        help="If enabled, facilitators can reuse curated templates when creating new content.",
+    )
+
+    tag_ids = fields.Many2many(
+        'course.course.tag',
+        'course_course_tag_rel',
+        'course_id',
+        'tag_id',
+        string='Tags',
+        help='Organise courses with thematic tags.',
+    )
+
+    _sql_constraints = [
+        ("course_code_unique", "unique(code)", "The course code must be unique."),
+    ]
+
+    @api.depends("content_ids", "content_ids.active")
+    def _compute_metrics(self):
+        for course in self:
+            contents = course.content_ids.filtered(lambda c: c.active)
+            course.total_content = len(contents)
+            course.total_attendees = len(course.attendee_ids)
+
+    @api.depends("attendee_ids.progress")
+    def _compute_avg_progress(self):
+        for course in self:
+            if course.attendee_ids:
+                course.avg_progress = sum(course.attendee_ids.mapped("progress")) / len(
+                    course.attendee_ids
+                )
+            else:
+                course.avg_progress = 0.0
+
+    def action_view_contents(self):
+        self.ensure_one()
+        action = self.env.ref("course_hub.action_course_content").read()[0]
+        action["domain"] = [("course_id", "=", self.id)]
+        action["context"] = {
+            "default_course_id": self.id,
+            "default_allow_template_upload": self.allow_template_upload,
+        }
+        return action
+
+    def action_view_attendees(self):
+        self.ensure_one()
+        action = self.env.ref("course_hub.action_course_attendee").read()[0]
+        action["domain"] = [("course_id", "=", self.id)]
+        action["context"] = {"default_course_id": self.id}
+        return action
+
+    def action_toggle_templates(self):
+        for course in self:
+            course.allow_template_upload = not course.allow_template_upload
+
+
+class CourseCourseTag(models.Model):
+    _name = "course.course.tag"
+    _description = "Course Tag"
+
+    name = fields.Char(required=True)
+    color = fields.Integer(default=0)
+    course_ids = fields.Many2many(
+        'course.course',
+        'course_course_tag_rel',
+        'tag_id',
+        'course_id',
+        string='Courses',
+    )
+
+    _sql_constraints = [
+        ("course_tag_name_unique", "unique(name)", "The tag name must be unique."),
+    ]

--- a/course_hub/security/ir.model.access.csv
+++ b/course_hub/security/ir.model.access.csv
@@ -1,0 +1,6 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_course_course_user,access_course_course_user,model_course_course,base.group_user,1,1,1,1
+access_course_content_user,access_course_content_user,model_course_content,base.group_user,1,1,1,1
+access_course_attendee_user,access_course_attendee_user,model_course_attendee,base.group_user,1,1,1,1
+access_course_content_template_user,access_course_content_template_user,model_course_content_template,base.group_user,1,1,1,1
+access_course_course_tag_user,access_course_course_tag_user,model_course_course_tag,base.group_user,1,1,1,1

--- a/course_hub/views/course_menus.xml
+++ b/course_hub/views/course_menus.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="menu_course_root" name="Course Hub" sequence="10" />
+
+    <record id="action_course_course" model="ir.actions.act_window">
+        <field name="name">Courses</field>
+        <field name="res_model">course.course</field>
+        <field name="view_mode">kanban,list,form,calendar</field>
+        <field name="context">{"default_responsible_id": uid}</field>
+    </record>
+
+    <menuitem id="menu_course_management" name="Kurse" parent="menu_course_root" sequence="5" action="action_course_course" />
+
+    <record id="action_course_content" model="ir.actions.act_window">
+        <field name="name">Inhalte</field>
+        <field name="res_model">course.content</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_course_content" name="Inhalte" parent="menu_course_root" sequence="10" action="action_course_content" />
+
+    <record id="action_course_attendee" model="ir.actions.act_window">
+        <field name="name">Teilnehmende</field>
+        <field name="res_model">course.attendee</field>
+        <field name="view_mode">list,form,pivot,graph</field>
+    </record>
+
+    <menuitem id="menu_course_attendee" name="Teilnehmende" parent="menu_course_root" sequence="15" action="action_course_attendee" />
+
+    <record id="action_course_template" model="ir.actions.act_window">
+        <field name="name">Templates</field>
+        <field name="res_model">course.content.template</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="context">{"default_is_recommended": True}</field>
+    </record>
+
+    <menuitem id="menu_course_templates" name="Templates" parent="menu_course_root" sequence="20" action="action_course_template" />
+</odoo>

--- a/course_hub/views/course_views.xml
+++ b/course_hub/views/course_views.xml
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Course Views -->
+    <record id="view_course_list" model="ir.ui.view">
+        <field name="name">course.course.list</field>
+        <field name="model">course.course</field>
+        <field name="arch" type="xml">
+            <list string="Courses" create="1" editable="bottom">
+                <field name="name" required="1" />
+                <field name="code" optional="show" />
+                <field name="responsible_id" optional="hide" />
+                <field name="total_content" optional="show" />
+                <field name="total_attendees" optional="show" />
+                <field name="avg_progress" widget="progressbar" optional="show" />
+                <field name="active" optional="hide" />
+            </list>
+        </field>
+    </record>
+
+    <record id="view_course_kanban" model="ir.ui.view">
+        <field name="name">course.course.kanban</field>
+        <field name="model">course.course</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_small_column" default_group_by="responsible_id">
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_content">
+                            <field name="name" class="fw-bold" />
+                            <div class="text-muted">
+                                <span t-if="record.code.raw_value">[<field name="code" />]</span>
+                                <span t-if="record.total_content.raw_value"> · <field name="total_content" /> Inhalte</span>
+                            </div>
+                            <div class="mt-2">
+                                <field name="avg_progress" widget="progressbar" options="{'max_value': 100}" />
+                            </div>
+                            <div class="mt-2 text-muted small">
+                                <span>
+                                    <i class="fa fa-users" />
+                                    <field name="total_attendees" /> Teilnehmende
+                                </span>
+                            </div>
+                        </div>
+                        <div class="o_kanban_footer">
+                            <a type="object" name="action_view_contents" class="btn btn-sm btn-link">Inhalte</a>
+                            <a type="object" name="action_view_attendees" class="btn btn-sm btn-link">Teilnehmende</a>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="view_course_form" model="ir.ui.view">
+        <field name="name">course.course.form</field>
+        <field name="model">course.course</field>
+        <field name="arch" type="xml">
+            <form string="Course" create="1" edit="1">
+                <header>
+                    <button name="action_toggle_templates" string="Templates umschalten" type="object" class="oe_highlight" />
+                </header>
+                <sheet>
+                    <div class="o_row">
+                        <group>
+                            <field name="name" />
+                            <field name="code" />
+                            <field name="responsible_id" />
+                            <field name="allow_template_upload" />
+                        </group>
+                        <group>
+                            <field name="total_content" readonly="1" />
+                            <field name="total_attendees" readonly="1" />
+                            <field name="avg_progress" readonly="1" widget="progressbar" options="{'max_value': 100}" />
+                        </group>
+                    </div>
+                    <notebook>
+                        <page string="Beschreibung">
+                            <field name="description" nolabel="1" />
+                        </page>
+                        <page string="Inhalte">
+                            <field name="content_ids">
+                                <list editable="bottom">
+                                    <field name="sequence" widget="handle" />
+                                    <field name="name" />
+                                    <field name="content_type" />
+                                    <field name="template_id" optional="show" />
+                                    <field name="duration" optional="show" />
+                                    <field name="is_template_based" readonly="1" optional="hide" />
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Teilnehmende">
+                            <field name="attendee_ids">
+                                <list>
+                                    <field name="partner_id" />
+                                    <field name="progress" widget="progressbar" />
+                                    <field name="state" />
+                                    <field name="enrollment_date" optional="hide" />
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Tags">
+                            <field name="tag_ids" widget="many2many_tags" />
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter />
+            </form>
+        </field>
+    </record>
+
+    <record id="view_course_search" model="ir.ui.view">
+        <field name="name">course.course.search</field>
+        <field name="model">course.course</field>
+        <field name="arch" type="xml">
+            <search string="Courses">
+                <field name="name" />
+                <field name="code" />
+                <filter string="Aktiv" name="active" domain="[('active', '=', True)]" />
+                <filter string="Inaktiv" name="inactive" domain="[('active', '=', False)]" />
+                <group expand="0" string="Gruppieren nach">
+                    <filter string="Verantwortliche" name="group_responsible" context="{'group_by': 'responsible_id'}" />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Content views -->
+    <record id="view_content_list" model="ir.ui.view">
+        <field name="name">course.content.list</field>
+        <field name="model">course.content</field>
+        <field name="arch" type="xml">
+            <list string="Inhalte">
+                <field name="sequence" widget="handle" />
+                <field name="name" />
+                <field name="course_id" optional="show" />
+                <field name="content_type" />
+                <field name="template_id" optional="show" />
+                <field name="duration" optional="show" />
+                <field name="is_template_based" widget="boolean_toggle" optional="hide" />
+                <field name="active" optional="hide" />
+            </list>
+        </field>
+    </record>
+
+    <record id="view_content_form" model="ir.ui.view">
+        <field name="name">course.content.form</field>
+        <field name="model">course.content</field>
+        <field name="arch" type="xml">
+            <form string="Content">
+                <header>
+                    <field name="active" widget="boolean_button" />
+                </header>
+                <sheet>
+                    <group>
+                        <field name="course_id" />
+                        <field name="name" />
+                        <field name="content_type" />
+                        <field name="template_id" attrs="{'invisible': [('course_id.allow_template_upload', '=', False)]}" />
+                    </group>
+                    <group>
+                        <field name="duration" />
+                        <field name="resource_url" />
+                        <field name="attachment_id" widget="many2one_binary" options="{'no_create': True}" />
+                        <field name="is_template_based" readonly="1" />
+                    </group>
+                    <group string="Beschreibung">
+                        <field name="description" nolabel="1" />
+                    </group>
+                </sheet>
+                <chatter />
+            </form>
+        </field>
+    </record>
+
+    <record id="view_content_search" model="ir.ui.view">
+        <field name="name">course.content.search</field>
+        <field name="model">course.content</field>
+        <field name="arch" type="xml">
+            <search string="Inhalte">
+                <field name="name" />
+                <field name="course_id" />
+                <field name="content_type" />
+                <filter string="Aktiv" name="active" domain="[('active', '=', True)]" />
+                <filter string="Inaktiv" name="inactive" domain="[('active', '=', False)]" />
+                <group expand="0" string="Gruppieren nach">
+                    <filter string="Kurs" name="group_course" context="{'group_by': 'course_id'}" />
+                    <filter string="Typ" name="group_type" context="{'group_by': 'content_type'}" />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Attendee views -->
+    <record id="view_attendee_list" model="ir.ui.view">
+        <field name="name">course.attendee.list</field>
+        <field name="model">course.attendee</field>
+        <field name="arch" type="xml">
+            <list string="Teilnehmende">
+                <field name="partner_id" />
+                <field name="course_id" optional="show" />
+                <field name="progress" widget="progressbar" />
+                <field name="state" />
+                <field name="enrollment_date" optional="show" />
+            </list>
+        </field>
+    </record>
+
+    <record id="view_attendee_form" model="ir.ui.view">
+        <field name="name">course.attendee.form</field>
+        <field name="model">course.attendee</field>
+        <field name="arch" type="xml">
+            <form string="Teilnehmende">
+                <sheet>
+                    <group>
+                        <field name="partner_id" />
+                        <field name="course_id" />
+                        <field name="state" readonly="1" />
+                        <field name="progress" widget="progressbar" readonly="1" />
+                    </group>
+                    <group>
+                        <field name="enrollment_date" />
+                        <field name="completed_content_ids" widget="many2many_tags" />
+                    </group>
+                    <group>
+                        <field name="notes" />
+                    </group>
+                </sheet>
+                <footer>
+                    <button name="action_reset_progress" type="object" string="Fortschritt zurücksetzen" class="btn-secondary" />
+                </footer>
+                <chatter />
+            </form>
+        </field>
+    </record>
+
+    <record id="view_attendee_search" model="ir.ui.view">
+        <field name="name">course.attendee.search</field>
+        <field name="model">course.attendee</field>
+        <field name="arch" type="xml">
+            <search string="Teilnehmende">
+                <field name="partner_id" />
+                <field name="course_id" />
+                <filter string="Aktive" name="active_state" domain="[('state', '=', 'in_progress')]" />
+                <filter string="Abgeschlossen" name="done_state" domain="[('state', '=', 'done')]" />
+                <group expand="0" string="Gruppieren nach">
+                    <filter string="Kurs" name="group_course" context="{'group_by': 'course_id'}" />
+                    <filter string="Status" name="group_state" context="{'group_by': 'state'}" />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Template views -->
+    <record id="view_template_kanban" model="ir.ui.view">
+        <field name="name">course.content.template.kanban</field>
+        <field name="model">course.content.template</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="content_type" class="o_kanban_small_column">
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_content">
+                            <field name="name" class="fw-bold" />
+                            <div class="text-muted small">
+                                <field name="content_type" />
+                            </div>
+                            <div class="mt-2">
+                                <field name="description" widget="html" />
+                            </div>
+                            <div class="mt-2" t-if="record.default_duration.raw_value">
+                                <i class="fa fa-clock-o" />
+                                <span><field name="default_duration" /> Minuten</span>
+                            </div>
+                        </div>
+                        <div class="o_kanban_footer">
+                            <field name="is_recommended" widget="boolean_toggle" />
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="view_template_list" model="ir.ui.view">
+        <field name="name">course.content.template.list</field>
+        <field name="model">course.content.template</field>
+        <field name="arch" type="xml">
+            <list string="Templates">
+                <field name="name" />
+                <field name="content_type" />
+                <field name="default_duration" optional="show" />
+                <field name="is_recommended" widget="boolean_toggle" />
+            </list>
+        </field>
+    </record>
+
+    <record id="view_template_form" model="ir.ui.view">
+        <field name="name">course.content.template.form</field>
+        <field name="model">course.content.template</field>
+        <field name="arch" type="xml">
+            <form string="Template">
+                <sheet>
+                    <group>
+                        <field name="name" />
+                        <field name="content_type" />
+                        <field name="default_duration" />
+                    </group>
+                    <group>
+                        <field name="resource_url" />
+                        <field name="attachment_id" widget="many2one_binary" options="{'no_create': True}" />
+                        <field name="is_recommended" />
+                    </group>
+                    <group string="Beschreibung">
+                        <field name="description" nolabel="1" />
+                    </group>
+                    <group>
+                        <field name="tag_ids" widget="many2many_tags" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_template_search" model="ir.ui.view">
+        <field name="name">course.content.template.search</field>
+        <field name="model">course.content.template</field>
+        <field name="arch" type="xml">
+            <search string="Templates">
+                <field name="name" />
+                <field name="content_type" />
+                <filter string="Empfohlen" name="recommended" domain="[('is_recommended', '=', True)]" />
+                <group expand="0" string="Gruppieren nach">
+                    <filter string="Typ" name="group_type" context="{'group_by': 'content_type'}" />
+                </group>
+            </search>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add the Course Hub backend app for Odoo 18 with courses, attendees, content, and tags
- introduce curated content templates and list-based views with progress indicators
- seed starter tags/templates and document installation and non-gamified scope in the repository README

## Testing
- python -m compileall course_hub

------
https://chatgpt.com/codex/tasks/task_e_68e7bf508fa48321bf5a0907a6b26213