### PR TITLE
Add backend course studio module for Odoo 18

### DIFF
--- a/custom_addons/course_enhancement/__init__.py
+++ b/custom_addons/course_enhancement/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/custom_addons/course_enhancement/__manifest__.py
+++ b/custom_addons/course_enhancement/__manifest__.py
@@ -1,0 +1,23 @@
+{
+    "name": "Enhanced Course Studio",
+    "summary": "Backend course management with content templates and participant progress.",
+    "version": "18.0.1.0.0",
+    "category": "Website/eLearning",
+    "website": "https://example.com",
+    "author": "Custom",
+    "license": "LGPL-3",
+    "depends": [
+        "website_slides",
+        "survey"
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/course_menu.xml",
+        "views/slide_channel_views.xml",
+        "views/slide_channel_partner_views.xml",
+        "views/slide_slide_views.xml",
+        "views/slide_content_template_views.xml"
+    ],
+    "installable": True,
+    "application": True,
+}

--- a/custom_addons/course_enhancement/models/__init__.py
+++ b/custom_addons/course_enhancement/models/__init__.py
@@ -1,0 +1,4 @@
+from . import slide_channel
+from . import slide_channel_partner
+from . import slide_slide
+from . import slide_content_template

--- a/custom_addons/course_enhancement/models/slide_channel.py
+++ b/custom_addons/course_enhancement/models/slide_channel.py
@@ -1,0 +1,73 @@
+from odoo import api, fields, models
+
+
+class SlideChannel(models.Model):
+    """Extend eLearning courses with backend-centric defaults."""
+
+    _inherit = "slide.channel"
+
+    attendance_backend_only = fields.Boolean(
+        string="Attendance in Backend",
+        default=True,
+        help="Restrict attendee registration to internal users only.",
+    )
+    default_template_id = fields.Many2one(
+        "slide.content.template",
+        string="Preferred Content Template",
+        help="Default template suggested when new course content is created.",
+    )
+    participant_count = fields.Integer(
+        string="Teilnehmer",
+        compute="_compute_progress_metrics",
+        store=True,
+    )
+    average_progress = fields.Float(
+        string="Durchschnittlicher Fortschritt",
+        compute="_compute_progress_metrics",
+        store=True,
+        digits="Percentage",
+    )
+
+    @api.model
+    def create(self, vals):
+        vals = self._apply_gamification_defaults(vals)
+        return super().create(vals)
+
+    def write(self, vals):
+        vals = self._apply_gamification_defaults(vals)
+        return super().write(vals)
+
+    def _apply_gamification_defaults(self, vals):
+        """Force gamification and karma features to stay disabled."""
+        disabled_fields = [
+            field_name
+            for field_name in (
+                "use_karma",
+                "karma_enabled",
+                "allow_rating",
+                "enable_gamification",
+                "karma_reward",
+                "karma_gen_slide_channel",
+                "use_karma_email_template",
+            )
+            if field_name in self._fields
+        ]
+        for field_name in disabled_fields:
+            vals[field_name] = False
+        return vals
+
+    @api.depends("channel_partner_ids", "channel_partner_ids.progress_percentage")
+    def _compute_progress_metrics(self):
+        for channel in self:
+            partners = channel.channel_partner_ids
+            channel.participant_count = len(partners)
+            if partners:
+                channel.average_progress = sum(partners.mapped("progress_percentage")) / len(partners)
+            else:
+                channel.average_progress = 0.0
+
+    def action_view_participant_progress(self):
+        action = self.env.ref("course_enhancement.action_course_partner_progress").read()[0]
+        action["domain"] = [("channel_id", "=", self.id)]
+        action["context"] = dict(self.env.context, default_channel_id=self.id)
+        return action

--- a/custom_addons/course_enhancement/models/slide_channel_partner.py
+++ b/custom_addons/course_enhancement/models/slide_channel_partner.py
@@ -1,0 +1,28 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import AccessError
+
+
+class SlideChannelPartner(models.Model):
+    _inherit = "slide.channel.partner"
+
+    progress_percentage = fields.Float(
+        string="Fortschritt",
+        compute="_compute_progress_percentage",
+        store=True,
+        digits="Percentage",
+    )
+
+    @api.depends("completed_slide_ids", "channel_id.slide_ids")
+    def _compute_progress_percentage(self):
+        for attendee in self:
+            total = len(attendee.channel_id.slide_ids)
+            completed = len(attendee.completed_slide_ids)
+            attendee.progress_percentage = (completed / total * 100.0) if total else 0.0
+
+    @api.model
+    def create(self, vals):
+        if not self.env.user.has_group("base.group_user"):
+            raise AccessError(
+                _("Attendance can only be created by backend users. Please contact your course manager.")
+            )
+        return super().create(vals)

--- a/custom_addons/course_enhancement/models/slide_content_template.py
+++ b/custom_addons/course_enhancement/models/slide_content_template.py
@@ -1,0 +1,32 @@
+from odoo import fields, models
+
+
+class SlideContentTemplate(models.Model):
+    _name = "slide.content.template"
+    _description = "Slide Content Template"
+    _order = "name"
+
+    name = fields.Char(required=True)
+    description = fields.Text()
+    slide_type = fields.Selection(
+        [
+            ("document", "Dokument"),
+            ("presentation", "Präsentation"),
+            ("video", "Video"),
+            ("quiz", "Quiz"),
+        ],
+        string="Content Type",
+        default="document",
+    )
+    body_html = fields.Html(string="Rich Content")
+    estimated_duration = fields.Integer(
+        string="Estimated Duration (minutes)",
+        help="Suggested duration for the learning unit.",
+    )
+    tag_ids = fields.Many2many(
+        "slide.tag",
+        "slide_content_template_tag_rel",
+        "template_id",
+        "tag_id",
+        string="Suggested Tags",
+    )

--- a/custom_addons/course_enhancement/models/slide_slide.py
+++ b/custom_addons/course_enhancement/models/slide_slide.py
@@ -1,0 +1,62 @@
+from odoo import api, fields, models
+
+
+class SlideSlide(models.Model):
+    _inherit = "slide.slide"
+
+    template_id = fields.Many2one(
+        "slide.content.template",
+        string="Content Template",
+        help="Template used to pre-fill structured learning content.",
+    )
+
+    @api.onchange("channel_id")
+    def _onchange_channel_default_template(self):
+        if self.channel_id and self.channel_id.default_template_id:
+            self.template_id = self.channel_id.default_template_id
+
+    @api.onchange("template_id")
+    def _onchange_template_id(self):
+        if self.template_id:
+            template = self.template_id
+            if template.name and not self.name:
+                self.name = template.name
+            if template.description:
+                self.description = template.description
+            if template.body_html:
+                self.html_content = template.body_html
+            if template.slide_type and (not self.slide_type or self.slide_type == "document"):
+                self.slide_type = template.slide_type
+
+    @api.model
+    def create(self, vals):
+        if not vals.get("template_id") and vals.get("channel_id"):
+            channel = self.env["slide.channel"].browse(vals["channel_id"])
+            if channel and channel.default_template_id:
+                vals.setdefault("template_id", channel.default_template_id.id)
+        record = super().create(vals)
+        template = record.template_id
+        if template:
+            record._apply_template(template)
+        return record
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "template_id" in vals:
+            for slide in self:
+                if slide.template_id:
+                    slide._apply_template(slide.template_id)
+        return res
+
+    def _apply_template(self, template):
+        update_vals = {}
+        if template.name and not self.name:
+            update_vals["name"] = template.name
+        if template.description and not self.description:
+            update_vals["description"] = template.description
+        if template.body_html and not self.html_content:
+            update_vals["html_content"] = template.body_html
+        if template.slide_type and not self.slide_type:
+            update_vals["slide_type"] = template.slide_type
+        if update_vals:
+            super(SlideSlide, self).write(update_vals)

--- a/custom_addons/course_enhancement/security/ir.model.access.csv
+++ b/custom_addons/course_enhancement/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_slide_content_template_user,access_slide_content_template_user,model_slide_content_template,base.group_user,1,1,1,1
+access_slide_content_template_manager,access_slide_content_template_manager,model_slide_content_template,base.group_system,1,1,1,1

--- a/custom_addons/course_enhancement/views/course_menu.xml
+++ b/custom_addons/course_enhancement/views/course_menu.xml
@@ -1,0 +1,24 @@
+<odoo>
+    <record id="action_course_channel" model="ir.actions.act_window">
+        <field name="name">Kurse</field>
+        <field name="res_model">slide.channel</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="context">{"search_default_my_channel": 1}</field>
+    </record>
+
+    <record id="action_course_partner_progress" model="ir.actions.act_window">
+        <field name="name">Teilnehmerfortschritt</field>
+        <field name="res_model">slide.channel.partner</field>
+        <field name="view_mode">list,form,kanban</field>
+    </record>
+
+    <record id="action_slide_content_template" model="ir.actions.act_window">
+        <field name="name">Inhaltsvorlagen</field>
+        <field name="res_model">slide.content.template</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_course_root" name="Course Studio" sequence="10"/>
+    <menuitem id="menu_course_courses" name="Kurse" parent="menu_course_root" action="action_course_channel" sequence="10"/>
+    <menuitem id="menu_course_templates" name="Inhaltsvorlagen" parent="menu_course_root" action="action_slide_content_template" sequence="20"/>
+</odoo>

--- a/custom_addons/course_enhancement/views/slide_channel_partner_views.xml
+++ b/custom_addons/course_enhancement/views/slide_channel_partner_views.xml
@@ -1,0 +1,77 @@
+<odoo>
+    <record id="view_course_channel_partner_list" model="ir.ui.view">
+        <field name="name">slide.channel.partner.progress.list</field>
+        <field name="model">slide.channel.partner</field>
+        <field name="arch" type="xml">
+            <list string="Teilnehmer" editable="bottom">
+                <field name="partner_id"/>
+                <field name="channel_id"/>
+                <field name="progress_percentage" widget="progressbar"/>
+                <field name="completed_slide_ids" widget="many2many_tags" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_course_channel_partner_form" model="ir.ui.view">
+        <field name="name">slide.channel.partner.progress.form</field>
+        <field name="model">slide.channel.partner</field>
+        <field name="arch" type="xml">
+            <form string="Teilnehmer">
+                <sheet>
+                    <group>
+                        <field name="partner_id"/>
+                        <field name="channel_id" readonly="1"/>
+                        <field name="progress_percentage" widget="progressbar" readonly="1"/>
+                    </group>
+                    <group>
+                        <field name="completed_slide_ids" widget="many2many_tags" readonly="1"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_course_channel_partner_kanban" model="ir.ui.view">
+        <field name="name">slide.channel.partner.progress.kanban</field>
+        <field name="model">slide.channel.partner</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="channel_id" class="oe_background_grey">
+                <field name="progress_percentage"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_global_click">
+                            <strong t-field="record.partner_id.value"/>
+                            <div class="mt-2">
+                                <span class="text-muted">Fortschritt</span>
+                                <div class="o_progressbar">
+                                    <div class="o_progress" t-att-style="'width: %s%%' % record.progress_percentage.value">
+                                        <span t-esc="int(record.progress_percentage.value)"/>%
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="mt-2">
+                                <span class="text-muted">Abgeschlossene Einheiten</span>
+                                <span t-esc="len(record.completed_slide_ids.raw_value or [])"/>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="view_course_channel_partner_search" model="ir.ui.view">
+        <field name="name">slide.channel.partner.progress.search</field>
+        <field name="model">slide.channel.partner</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="partner_id"/>
+                <field name="channel_id"/>
+                <filter string="Fortschritt &lt; 50%" name="progress_low" domain="[('progress_percentage', '&lt;', 50)]"/>
+                <group expand="0" string="Gruppieren nach">
+                    <filter string="Kurs" context="{'group_by': 'channel_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+</odoo>

--- a/custom_addons/course_enhancement/views/slide_channel_views.xml
+++ b/custom_addons/course_enhancement/views/slide_channel_views.xml
@@ -1,0 +1,82 @@
+<odoo>
+    <record id="view_course_channel_list" model="ir.ui.view">
+        <field name="name">slide.channel.course.list</field>
+        <field name="model">slide.channel</field>
+        <field name="arch" type="xml">
+            <list string="Kurse">
+                <field name="name"/>
+                <field name="responsible_id"/>
+                <field name="participant_count" widget="statinfo"/>
+                <field name="average_progress" widget="progressbar"/>
+                <field name="create_date"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_course_channel_form" model="ir.ui.view">
+        <field name="name">slide.channel.course.form</field>
+        <field name="model">slide.channel</field>
+        <field name="arch" type="xml">
+            <form string="Kurs">
+                <header>
+                    <button name="action_view_participant_progress" type="object" string="Teilnehmer" class="oe_highlight"/>
+                </header>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="category" optional="hide"/>
+                            <field name="responsible_id"/>
+                            <field name="default_template_id"/>
+                        </group>
+                        <group>
+                            <field name="description" widget="text" colspan="2"/>
+                            <field name="attendance_backend_only" readonly="1"/>
+                        </group>
+                    </group>
+                    <group>
+                        <field name="participant_count" readonly="1" widget="statinfo"/>
+                        <field name="average_progress" readonly="1" widget="progressbar"/>
+                    </group>
+                    <notebook>
+                        <page string="Inhalte">
+                            <field name="slide_ids" context="{'default_channel_id': active_id}" options="{'no_open': False}">
+                                <list editable="bottom">
+                                    <field name="name"/>
+                                    <field name="slide_type"/>
+                                    <field name="template_id"/>
+                                    <field name="sequence" optional="hide"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Teilnehmer">
+                            <field name="channel_partner_ids" context="{'default_channel_id': active_id}" options="{'no_create': False}">
+                                <list>
+                                    <field name="partner_id"/>
+                                    <field name="progress_percentage" widget="progressbar"/>
+                                    <field name="completed_slide_ids" widget="many2many_tags" optional="hide"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_course_channel_search" model="ir.ui.view">
+        <field name="name">slide.channel.course.search</field>
+        <field name="model">slide.channel</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <filter string="Meine Kurse" name="my_courses" domain="[('responsible_id', '=', uid)]"/>
+                <filter string="Mit Teilnehmern" name="with_attendees" domain="[('participant_count', '>', 0)]"/>
+                <group expand="0" string="Gruppieren nach">
+                    <filter string="Verantwortlicher" context="{'group_by': 'responsible_id'}"/>
+                    <filter string="Kategorie" context="{'group_by': 'category'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+</odoo>

--- a/custom_addons/course_enhancement/views/slide_content_template_views.xml
+++ b/custom_addons/course_enhancement/views/slide_content_template_views.xml
@@ -1,0 +1,40 @@
+<odoo>
+    <record id="view_slide_content_template_list" model="ir.ui.view">
+        <field name="name">slide.content.template.list</field>
+        <field name="model">slide.content.template</field>
+        <field name="arch" type="xml">
+            <list string="Inhaltsvorlagen">
+                <field name="name"/>
+                <field name="slide_type"/>
+                <field name="estimated_duration" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_slide_content_template_form" model="ir.ui.view">
+        <field name="name">slide.content.template.form</field>
+        <field name="model">slide.content.template</field>
+        <field name="arch" type="xml">
+            <form string="Inhaltsvorlage">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="slide_type"/>
+                        <field name="estimated_duration"/>
+                    </group>
+                    <notebook>
+                        <page string="Beschreibung">
+                            <field name="description" widget="text"/>
+                        </page>
+                        <page string="Inhalt">
+                            <field name="body_html"/>
+                        </page>
+                        <page string="Tags">
+                            <field name="tag_ids" widget="many2many_tags"/>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/custom_addons/course_enhancement/views/slide_slide_views.xml
+++ b/custom_addons/course_enhancement/views/slide_slide_views.xml
@@ -1,0 +1,23 @@
+<odoo>
+    <record id="view_slide_slide_form_inherit_template" model="ir.ui.view">
+        <field name="name">slide.slide.form.template.inherit</field>
+        <field name="model">slide.slide</field>
+        <field name="inherit_id" ref="website_slides.slide_slide_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="template_id" options="{'no_create': False}"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_slide_slide_list_inherit_template" model="ir.ui.view">
+        <field name="name">slide.slide.list.template.inherit</field>
+        <field name="model">slide.slide</field>
+        <field name="inherit_id" ref="website_slides.view_slide_slide_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="template_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add the Enhanced Course Studio module for Odoo 18 with menus and access rights
- extend slide channels to disable gamification, prefer backend attendance, and surface participant progress
- introduce reusable content templates with template-aware slide forms and participant progress dashboards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7bf508fa48321bf5a0907a6b26213