### PR TITLE
Add binary survey integration for quiz slides

### DIFF
--- a/custom_addons/course_enhancement/models/__init__.py
+++ b/custom_addons/course_enhancement/models/__init__.py
@@ -2,3 +2,4 @@ from . import slide_channel
 from . import slide_channel_partner
 from . import slide_slide
 from . import slide_content_template
+from . import survey_models

--- a/custom_addons/course_enhancement/models/slide_slide.py
+++ b/custom_addons/course_enhancement/models/slide_slide.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class SlideSlide(models.Model):
@@ -8,6 +8,13 @@ class SlideSlide(models.Model):
         "slide.content.template",
         string="Content Template",
         help="Template used to pre-fill structured learning content.",
+    )
+    survey_id = fields.Many2one(
+        "survey.survey",
+        string="Survey",
+        ondelete="set null",
+        help="Assessment linked to this quiz slide for binary scoring.",
+        domain="[('survey_type', '=', 'assessment')]",
     )
 
     @api.onchange("channel_id")
@@ -34,18 +41,23 @@ class SlideSlide(models.Model):
             channel = self.env["slide.channel"].browse(vals["channel_id"])
             if channel and channel.default_template_id:
                 vals.setdefault("template_id", channel.default_template_id.id)
+        vals = self._prepare_quiz_survey_vals(vals)
         record = super().create(vals)
         template = record.template_id
         if template:
             record._apply_template(template)
+        record._sync_quiz_survey_title()
         return record
 
     def write(self, vals):
-        res = super().write(vals)
-        if "template_id" in vals:
-            for slide in self:
-                if slide.template_id:
-                    slide._apply_template(slide.template_id)
+        res = True
+        for slide in self:
+            update_vals = slide._prepare_quiz_survey_vals(dict(vals), current_slide=slide)
+            res = super(SlideSlide, slide).write(update_vals) and res
+            if "template_id" in update_vals and slide.template_id:
+                slide._apply_template(slide.template_id)
+            if any(field in vals for field in ["name", "survey_id", "slide_type"]):
+                slide._sync_quiz_survey_title()
         return res
 
     def _apply_template(self, template):
@@ -60,3 +72,37 @@ class SlideSlide(models.Model):
             update_vals["slide_type"] = template.slide_type
         if update_vals:
             super(SlideSlide, self).write(update_vals)
+
+    def _prepare_quiz_survey_vals(self, vals, current_slide=None):
+        """Ensure quiz slides always reference an assessment survey."""
+        prepared_vals = dict(vals)
+        slide_type = prepared_vals.get("slide_type") or (current_slide.slide_type if current_slide else False)
+        if slide_type == "quiz":
+            if not prepared_vals.get("survey_id"):
+                if current_slide and current_slide.survey_id:
+                    prepared_vals["survey_id"] = current_slide.survey_id.id
+                else:
+                    survey = self._create_binary_survey(prepared_vals, current_slide=current_slide)
+                    prepared_vals["survey_id"] = survey.id
+        elif "slide_type" in prepared_vals or (current_slide and current_slide.slide_type == "quiz"):
+            prepared_vals.setdefault("survey_id", False)
+        return prepared_vals
+
+    def _create_binary_survey(self, vals, current_slide=None):
+        title = vals.get("name")
+        if not title and current_slide:
+            title = current_slide.name
+        if not title:
+            title = _("Quiz")
+        return self.env["survey.survey"].create(
+            {
+                "title": title,
+                "survey_type": "assessment",
+                "scoring_type": "scoring_with_answers",
+            }
+        )
+
+    def _sync_quiz_survey_title(self):
+        for slide in self.filtered(lambda s: s.slide_type == "quiz" and s.survey_id):
+            if slide.name:
+                slide.survey_id.sudo().write({"title": slide.name})

--- a/custom_addons/course_enhancement/models/survey_models.py
+++ b/custom_addons/course_enhancement/models/survey_models.py
@@ -1,0 +1,130 @@
+from odoo import api, fields, models
+
+
+class SurveySurvey(models.Model):
+    _inherit = "survey.survey"
+
+    def _disable_gamification_values(self, vals):
+        disabled_fields = [
+            "certification_give_badge",
+            "certification_badge_id",
+            "session_speed_rating",
+        ]
+        result = dict(vals)
+        for field_name in disabled_fields:
+            if field_name in self._fields:
+                result[field_name] = False
+        return result
+
+    @api.model
+    def create(self, vals):
+        vals = self._disable_gamification_values(vals)
+        return super().create(vals)
+
+    def write(self, vals):
+        vals = self._disable_gamification_values(vals)
+        return super().write(vals)
+
+
+class SurveyQuestionAnswer(models.Model):
+    _inherit = "survey.question.answer"
+
+    def _prepare_binary_score(self, vals):
+        prepared_vals = dict(vals)
+        if "is_correct" in prepared_vals:
+            prepared_vals["answer_score"] = 1.0 if prepared_vals["is_correct"] else 0.0
+        elif "answer_score" not in prepared_vals:
+            is_correct = None
+            if self:
+                is_correct = self.is_correct
+            if is_correct is not None:
+                prepared_vals.setdefault("answer_score", 1.0 if is_correct else 0.0)
+        return prepared_vals
+
+    @api.model
+    def create(self, vals):
+        vals = self._prepare_binary_score(vals)
+        return super().create(vals)
+
+    def write(self, vals):
+        res = True
+        for answer in self:
+            update_vals = answer._prepare_binary_score(dict(vals))
+            res = super(SurveyQuestionAnswer, answer).write(update_vals) and res
+        return res
+
+
+class SurveyUserInput(models.Model):
+    _inherit = "survey.user_input"
+
+    def _compute_scoring_values(self):
+        for user_input in self:
+            questions = user_input.predefined_question_ids.filtered(self._question_supports_binary_scoring)
+            total_questions = len(questions)
+            if not total_questions:
+                user_input.scoring_total = 0.0
+                user_input.scoring_percentage = 0.0
+                continue
+
+            correct_count = sum(
+                1 for question in questions if self._is_question_answer_correct(user_input, question)
+            )
+            user_input.scoring_total = float(correct_count)
+            percentage = (correct_count / total_questions) * 100.0
+            user_input.scoring_percentage = round(percentage, 2) if percentage else 0.0
+
+    def _question_supports_binary_scoring(self, question):
+        if question.question_type in ("simple_choice", "multiple_choice"):
+            return bool(question.suggested_answer_ids.filtered("is_correct"))
+        return question.is_scored_question
+
+    def _is_question_answer_correct(self, user_input, question):
+        if question.question_type == "multiple_choice":
+            lines = user_input.user_input_line_ids.filtered(
+                lambda line: line.question_id == question and not line.skipped and line.answer_type == "suggestion"
+            )
+            if not lines:
+                return False
+            selected_answer_ids = set(lines.mapped("suggested_answer_id").ids)
+            correct_answer_ids = set(question.suggested_answer_ids.filtered("is_correct").ids)
+            return selected_answer_ids == correct_answer_ids
+
+        if question.question_type == "simple_choice":
+            line = user_input.user_input_line_ids.filtered(
+                lambda l: l.question_id == question and not l.skipped and l.answer_type == "suggestion"
+            )
+            return len(line) == 1 and all(line.mapped("answer_is_correct"))
+
+        relevant_lines = user_input.user_input_line_ids.filtered(
+            lambda line: line.question_id == question and not line.skipped
+        )
+        return any(relevant_lines.mapped("answer_is_correct"))
+
+    def _multiple_choice_question_answer_result(self, user_input_lines, question_correct_suggested_answers):
+        relevant_lines = user_input_lines.filtered(
+            lambda line: not line.skipped and line.answer_type == "suggestion"
+        )
+        if not relevant_lines:
+            return "skipped"
+        selected_answer_ids = set(relevant_lines.mapped("suggested_answer_id").ids)
+        correct_answer_ids = set(question_correct_suggested_answers.ids)
+        return "correct" if selected_answer_ids == correct_answer_ids else "incorrect"
+
+    def _simple_choice_question_answer_result(
+        self, user_input_line, question_correct_suggested_answers, question_incorrect_scored_answers
+    ):
+        if user_input_line.skipped:
+            return "skipped"
+        if user_input_line.suggested_answer_id in question_correct_suggested_answers:
+            return "correct"
+        return "incorrect"
+
+
+class SurveyUserInputLine(models.Model):
+    _inherit = "survey.user_input.line"
+
+    @api.model
+    def _get_answer_score_values(self, vals, compute_speed_score=True):
+        values = super()._get_answer_score_values(vals, compute_speed_score=False)
+        values["answer_score"] = 1.0 if values.get("answer_is_correct") else 0.0
+        return values

--- a/custom_addons/course_enhancement/views/slide_slide_views.xml
+++ b/custom_addons/course_enhancement/views/slide_slide_views.xml
@@ -7,6 +7,9 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="template_id" options="{'no_create': False}"/>
             </xpath>
+            <xpath expr="//field[@name='slide_type']" position="after">
+                <field name="survey_id" attrs="{'invisible': [('slide_type', '!=', 'quiz')], 'required': [('slide_type', '=', 'quiz')]}"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
## Summary
- create and synchronize assessment surveys for quiz slides while keeping gamification disabled
- enforce binary (right/wrong) scoring throughout survey answers and attendee results
- expose the linked survey on quiz slides so editors can manage the assessment connection

## Testing
- python -m compileall custom_addons/course_enhancement

------
https://chatgpt.com/codex/tasks/task_e_68e7d98e87d483218469232a75a8a73e