### PR TITLE
Integrate surveys with eLearning quizzes

### DIFF
--- a/custom_addons/course_enhancement/__manifest__.py
+++ b/custom_addons/course_enhancement/__manifest__.py
@@ -16,7 +16,8 @@
         "views/slide_channel_views.xml",
         "views/slide_channel_partner_views.xml",
         "views/slide_slide_views.xml",
-        "views/slide_content_template_views.xml"
+        "views/slide_content_template_views.xml",
+        "views/survey_survey_views.xml"
     ],
     "installable": True,
     "application": True,

--- a/custom_addons/course_enhancement/models/__init__.py
+++ b/custom_addons/course_enhancement/models/__init__.py
@@ -2,3 +2,7 @@ from . import slide_channel
 from . import slide_channel_partner
 from . import slide_slide
 from . import slide_content_template
+from . import slide_question
+from . import survey_question
+from . import survey_question_answer
+from . import survey_survey

--- a/custom_addons/course_enhancement/models/slide_question.py
+++ b/custom_addons/course_enhancement/models/slide_question.py
@@ -1,0 +1,23 @@
+from odoo import models, fields
+
+
+class SlideQuestion(models.Model):
+    _inherit = "slide.question"
+
+    survey_question_id = fields.Many2one(
+        "survey.question",
+        string="Umfragefrage",
+        ondelete="set null",
+        help="Referenz zur ursprünglichen Survey-Frage für Synchronisierungen.",
+    )
+
+
+class SlideAnswer(models.Model):
+    _inherit = "slide.answer"
+
+    survey_answer_id = fields.Many2one(
+        "survey.question.answer",
+        string="Umfrageantwort",
+        ondelete="set null",
+        help="Referenz zur ursprünglichen Survey-Antwort für Synchronisierungen.",
+    )

--- a/custom_addons/course_enhancement/models/slide_slide.py
+++ b/custom_addons/course_enhancement/models/slide_slide.py
@@ -9,6 +9,12 @@ class SlideSlide(models.Model):
         string="Content Template",
         help="Template used to pre-fill structured learning content.",
     )
+    survey_id = fields.Many2one(
+        "survey.survey",
+        string="Verknüpfte Umfrage",
+        help="Quizfragen aus dieser Umfrage werden mit dem Inhalt synchronisiert.",
+        domain="[('is_elearning_quiz', '=', True)]",
+    )
 
     @api.onchange("channel_id")
     def _onchange_channel_default_template(self):
@@ -30,6 +36,7 @@ class SlideSlide(models.Model):
 
     @api.model
     def create(self, vals):
+        vals = self._apply_quiz_rewards_defaults(vals)
         if not vals.get("template_id") and vals.get("channel_id"):
             channel = self.env["slide.channel"].browse(vals["channel_id"])
             if channel and channel.default_template_id:
@@ -38,14 +45,20 @@ class SlideSlide(models.Model):
         template = record.template_id
         if template:
             record._apply_template(template)
+        if record.survey_id:
+            record._sync_survey_questions_from_survey()
         return record
 
     def write(self, vals):
+        vals = self._apply_quiz_rewards_defaults(vals)
         res = super().write(vals)
         if "template_id" in vals:
             for slide in self:
                 if slide.template_id:
                     slide._apply_template(slide.template_id)
+        if "survey_id" in vals:
+            for slide in self:
+                slide._sync_survey_questions_from_survey()
         return res
 
     def _apply_template(self, template):
@@ -60,3 +73,77 @@ class SlideSlide(models.Model):
             update_vals["slide_type"] = template.slide_type
         if update_vals:
             super(SlideSlide, self).write(update_vals)
+
+    def _apply_quiz_rewards_defaults(self, vals):
+        rewards_fields = [
+            "quiz_first_attempt_reward",
+            "quiz_second_attempt_reward",
+            "quiz_third_attempt_reward",
+            "quiz_fourth_attempt_reward",
+        ]
+        # Ensure rewards are neutralised when gamification is disabled.
+        for field_name in rewards_fields:
+            if field_name in self._fields:
+                vals[field_name] = 0
+        return vals
+
+    def action_sync_survey_questions(self):
+        self.ensure_one()
+        self._sync_survey_questions_from_survey()
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": "Umfrage synchronisiert",
+                "message": "Die Fragen wurden aus der verknüpften Umfrage übernommen.",
+                "sticky": False,
+                "type": "success",
+            },
+        }
+
+    def _sync_survey_questions_from_survey(self):
+        for slide in self:
+            if not slide.survey_id:
+                continue
+            survey_questions = slide.survey_id.question_ids.filtered(
+                lambda q: not q.is_page and q.question_type in ("simple_choice", "multiple_choice")
+            )
+            sequence = 1
+            for survey_question in survey_questions:
+                answer_commands = [(5, 0, 0)]
+                for suggested_answer in survey_question.suggested_answer_ids:
+                    text_value = suggested_answer.value or suggested_answer.value_label or ""
+                    answer_commands.append(
+                        (
+                            0,
+                            0,
+                            {
+                                "text_value": text_value,
+                                "is_correct": suggested_answer.is_correct,
+                                "sequence": suggested_answer.sequence,
+                                "survey_answer_id": suggested_answer.id,
+                            },
+                        )
+                    )
+                question_vals = {
+                    "question": survey_question.title or "",
+                    "sequence": sequence,
+                    "survey_question_id": survey_question.id,
+                    "answer_ids": answer_commands,
+                }
+                existing_question = slide.question_ids.filtered(
+                    lambda q: q.survey_question_id == survey_question
+                )[:1]
+                if existing_question:
+                    existing_question.write(question_vals)
+                else:
+                    question_vals.update({"slide_id": slide.id})
+                    self.env["slide.question"].create(question_vals)
+                sequence += 1
+            # Remove orphan questions that are no longer present in the survey
+            linked_ids = survey_questions.ids
+            orphan_questions = slide.question_ids.filtered(
+                lambda q: q.survey_question_id and q.survey_question_id.id not in linked_ids
+            )
+            if orphan_questions:
+                orphan_questions.unlink()

--- a/custom_addons/course_enhancement/models/survey_question.py
+++ b/custom_addons/course_enhancement/models/survey_question.py
@@ -1,0 +1,31 @@
+from odoo import api, models
+
+
+class SurveyQuestion(models.Model):
+    _inherit = "survey.question"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        questions = super().create(vals_list)
+        questions._apply_elearning_binary_constraints()
+        return questions
+
+    def write(self, vals):
+        res = super().write(vals)
+        if not self.env.context.get("binary_scoring_skip"):
+            self._apply_elearning_binary_constraints()
+        return res
+
+    def _apply_elearning_binary_constraints(self):
+        for question in self:
+            survey = question.survey_id
+            if not survey or not survey.is_elearning_quiz:
+                continue
+            updates = {}
+            if question.question_type not in ("simple_choice", "multiple_choice"):
+                updates["question_type"] = "simple_choice"
+            if question.is_scored_question is not True:
+                updates["is_scored_question"] = True
+            if updates:
+                super(SurveyQuestion, question.with_context(binary_scoring_skip=True)).write(updates)
+            question.suggested_answer_ids._apply_elearning_binary_scores()

--- a/custom_addons/course_enhancement/models/survey_question_answer.py
+++ b/custom_addons/course_enhancement/models/survey_question_answer.py
@@ -1,0 +1,28 @@
+from odoo import api, models
+
+
+class SurveyQuestionAnswer(models.Model):
+    _inherit = "survey.question.answer"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        answers = super().create(vals_list)
+        answers._apply_elearning_binary_scores()
+        return answers
+
+    def write(self, vals):
+        res = super().write(vals)
+        if not self.env.context.get("binary_scoring_skip"):
+            self._apply_elearning_binary_scores()
+        return res
+
+    def _apply_elearning_binary_scores(self):
+        for answer in self:
+            question = answer.question_id or answer.matrix_question_id
+            if not question or not question.survey_id.is_elearning_quiz:
+                continue
+            desired_score = 1.0 if answer.is_correct else 0.0
+            if answer.answer_score != desired_score:
+                super(SurveyQuestionAnswer, answer.with_context(binary_scoring_skip=True)).write(
+                    {"answer_score": desired_score}
+                )

--- a/custom_addons/course_enhancement/models/survey_survey.py
+++ b/custom_addons/course_enhancement/models/survey_survey.py
@@ -1,0 +1,55 @@
+from odoo import api, fields, models
+
+
+class SurveySurvey(models.Model):
+    _inherit = "survey.survey"
+
+    is_elearning_quiz = fields.Boolean(
+        string="Für eLearning verwenden",
+        help="Aktivieren, um diese Umfrage mit eLearning-Inhalten zu synchronisieren."
+             " Gamification wird deaktiviert und Fragen werden binär bewertet.",
+    )
+    slide_ids = fields.One2many(
+        "slide.slide",
+        "survey_id",
+        string="Verknüpfte Folien",
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        vals_list = [self._prepare_elearning_defaults(vals) for vals in vals_list]
+        surveys = super().create(vals_list)
+        surveys._apply_elearning_binary_constraints()
+        return surveys
+
+    def write(self, vals):
+        res = super().write(self._prepare_elearning_defaults(vals))
+        if not self.env.context.get("binary_scoring_skip"):
+            self._apply_elearning_binary_constraints()
+        return res
+
+    def _prepare_elearning_defaults(self, vals):
+        vals = dict(vals)
+        if vals.get("is_elearning_quiz"):
+            vals.setdefault("survey_type", "assessment")
+            vals.setdefault("questions_layout", "page_per_question")
+            vals.setdefault("questions_selection", "all")
+            vals.setdefault("scoring_type", "scoring_with_answers")
+        return vals
+
+    def _apply_elearning_binary_constraints(self):
+        for survey in self:
+            if not survey.is_elearning_quiz:
+                continue
+            updates = {}
+            if survey.survey_type != "assessment":
+                updates["survey_type"] = "assessment"
+            if survey.questions_layout != "page_per_question":
+                updates["questions_layout"] = "page_per_question"
+            if survey.questions_selection != "all":
+                updates["questions_selection"] = "all"
+            if survey.scoring_type != "scoring_with_answers":
+                updates["scoring_type"] = "scoring_with_answers"
+            if updates:
+                super(SurveySurvey, survey.with_context(binary_scoring_skip=True)).write(updates)
+            survey.question_ids._apply_elearning_binary_constraints()

--- a/custom_addons/course_enhancement/views/slide_slide_views.xml
+++ b/custom_addons/course_enhancement/views/slide_slide_views.xml
@@ -6,6 +6,14 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="after">
                 <field name="template_id" options="{'no_create': False}"/>
+                <field name="survey_id" attrs="{'invisible': [('slide_category', '!=', 'quiz')]}"/>
+            </xpath>
+            <xpath expr="//header" position="inside">
+                <button name="action_sync_survey_questions"
+                        type="object"
+                        string="Umfrage synchronisieren"
+                        class="btn-primary"
+                        attrs="{'invisible': ['|', ('survey_id', '=', False), ('slide_category', '!=', 'quiz')]}"/>
             </xpath>
         </field>
     </record>
@@ -17,6 +25,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="after">
                 <field name="template_id"/>
+                <field name="survey_id" attrs="{'column_invisible': [('slide_category', '!=', 'quiz')]}"/>
             </xpath>
         </field>
     </record>

--- a/custom_addons/course_enhancement/views/survey_survey_views.xml
+++ b/custom_addons/course_enhancement/views/survey_survey_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_survey_form_inherit_elearning" model="ir.ui.view">
+        <field name="name">survey.survey.form.elearning</field>
+        <field name="model">survey.survey</field>
+        <field name="inherit_id" ref="survey.survey_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='survey_type']" position="after">
+                <field name="is_elearning_quiz"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- allow eLearning slides to link to surveys and sync quiz questions while disabling rewards
- enforce binary scoring for eLearning surveys and propagate correct/incorrect answers only
- expose the eLearning survey flag and linking fields in the backend views

## Testing
- python3 -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68e7d98e87d483218469232a75a8a73e