### PR TITLE
Add eLearning module without gamification

### DIFF
--- a/elearning_no_gamification/__init__.py
+++ b/elearning_no_gamification/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/elearning_no_gamification/__manifest__.py
+++ b/elearning_no_gamification/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "eLearning ohne Gamification",
+    "version": "18.0.1.0.0",
+    "depends": [
+        "website_slides",
+        "survey"
+    ],
+    "author": "",
+    "category": "Website",
+    "summary": "Deaktiviert Karma- und Gamification-Elemente in Odoo eLearning.",
+    "license": "LGPL-3",
+    "data": [
+        "security/ir.model.access.csv",
+        "views/assets.xml"
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/elearning_no_gamification/models/__init__.py
+++ b/elearning_no_gamification/models/__init__.py
@@ -1,0 +1,7 @@
+from . import no_karma_mixin
+from . import res_users
+from . import slide_channel
+from . import slide_channel_partner
+from . import slide_slide
+from . import slide_slide_partner
+from . import survey_user_input

--- a/elearning_no_gamification/models/no_karma_mixin.py
+++ b/elearning_no_gamification/models/no_karma_mixin.py
@@ -1,0 +1,28 @@
+"""Helper mixin to centralize the karma suppression logic."""
+
+from odoo import models
+
+
+class NoKarmaMixin:
+    """Mixin that provides helpers returning falsy values for karma hooks."""
+
+    def _suppress_karma(self, *args, **kwargs):
+        """Return ``False`` so caller can abort karma mutations."""
+        return False
+
+    def _suppress_karma_zero(self, *args, **kwargs):
+        """Return ``0`` for hooks that expect a numeric karma delta."""
+        return 0
+
+
+class NoKarmaModelMixin(NoKarmaMixin, models.AbstractModel):
+    """Abstract model to expose the helpers as model methods."""
+
+    _name = "elearning.no.karma.mixin"
+    _description = "eLearning mixin to disable karma side effects"
+
+    def _suppress_karma(self, *args, **kwargs):  # type: ignore[override]
+        return super()._suppress_karma(*args, **kwargs)
+
+    def _suppress_karma_zero(self, *args, **kwargs):  # type: ignore[override]
+        return super()._suppress_karma_zero(*args, **kwargs)

--- a/elearning_no_gamification/models/res_users.py
+++ b/elearning_no_gamification/models/res_users.py
@@ -1,0 +1,32 @@
+"""Overrides for ``res.users`` to neutralise karma adjustments."""
+
+from odoo import models
+
+from .no_karma_mixin import NoKarmaMixin
+
+
+class ResUsers(NoKarmaMixin, models.Model):
+    """Disable all public hooks adding or removing karma."""
+
+    _inherit = "res.users"
+
+    def add_karma(self, *args, **kwargs):  # type: ignore[override]
+        return self._suppress_karma(*args, **kwargs)
+
+    def _add_karma(self, *args, **kwargs):  # type: ignore[override]
+        return self._suppress_karma(*args, **kwargs)
+
+    def _add_karma_batch(self, *args, **kwargs):  # type: ignore[override]
+        return self._suppress_karma(*args, **kwargs)
+
+    def _increase_karma(self, *args, **kwargs):  # type: ignore[override]
+        return self._suppress_karma(*args, **kwargs)
+
+    def _decrease_karma(self, *args, **kwargs):  # type: ignore[override]
+        return self._suppress_karma(*args, **kwargs)
+
+    def _update_karma(self, *args, **kwargs):  # type: ignore[override]
+        return self._suppress_karma(*args, **kwargs)
+
+    def _set_karma(self, *args, **kwargs):  # type: ignore[override]
+        return self._suppress_karma(*args, **kwargs)

--- a/elearning_no_gamification/models/slide_channel.py
+++ b/elearning_no_gamification/models/slide_channel.py
@@ -1,0 +1,31 @@
+"""Karma overrides for ``slide.channel`` objects."""
+
+from collections import defaultdict
+
+from odoo import models
+
+from .no_karma_mixin import NoKarmaMixin
+
+
+class SlideChannel(NoKarmaMixin, models.Model):
+    _inherit = "slide.channel"
+
+    def _post_completion_update_hook(self, completed=True):  # type: ignore[override]
+        """Block karma gain when members finish or reopen a course."""
+        return self._suppress_karma(completed)
+
+    def _get_earned_karma(self, partner_ids):  # type: ignore[override]
+        """Return empty karma history so leaderboards stay blank."""
+        _ = partner_ids
+        return defaultdict(list)
+
+    def _compute_action_rights(self):  # type: ignore[override]
+        """Allow voting/commenting/reviewing without karma thresholds."""
+        for channel in self:
+            if channel.can_publish:
+                channel.can_vote = channel.can_comment = channel.can_review = True
+            elif not channel.is_member:
+                channel.can_vote = channel.can_comment = channel.can_review = False
+            else:
+                channel.can_vote = channel.can_comment = channel.can_review = True
+        return None

--- a/elearning_no_gamification/models/slide_channel_partner.py
+++ b/elearning_no_gamification/models/slide_channel_partner.py
@@ -1,0 +1,12 @@
+"""Disable karma rewards when completing channels."""
+
+from odoo import models
+
+from .no_karma_mixin import NoKarmaMixin
+
+
+class SlideChannelPartner(NoKarmaMixin, models.Model):
+    _inherit = "slide.channel.partner"
+
+    def _post_completion_update_hook(self, *args, **kwargs):  # type: ignore[override]
+        return self._suppress_karma(*args, **kwargs)

--- a/elearning_no_gamification/models/slide_slide.py
+++ b/elearning_no_gamification/models/slide_slide.py
@@ -1,0 +1,60 @@
+"""Monkey patches for slide.slide to suppress karma operations."""
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+from .no_karma_mixin import NoKarmaMixin
+
+
+class SlideSlide(NoKarmaMixin, models.Model):
+    _inherit = "slide.slide"
+
+    def _action_set_quiz_done(self, completed=True):  # type: ignore[override]
+        """Override to mark quizzes without touching karma."""
+        if any(not slide.channel_id.is_member or not slide.website_published for slide in self):
+            raise UserError(
+                _('You cannot mark a slide quiz as completed if you are not among its members or it is unpublished.')
+                if completed
+                else _('You cannot mark a slide quiz as not completed if you are not among its members or it is unpublished.')
+            )
+
+        for slide in self:
+            user_membership_sudo = slide.user_membership_id.sudo()
+            if (
+                not user_membership_sudo
+                or user_membership_sudo.completed == completed
+                or not user_membership_sudo.quiz_attempts_count
+                or not slide.question_ids
+            ):
+                continue
+
+            # keep the attempt counter logic untouched but skip karma updates entirely
+            gains = [
+                slide.quiz_first_attempt_reward,
+                slide.quiz_second_attempt_reward,
+                slide.quiz_third_attempt_reward,
+                slide.quiz_fourth_attempt_reward,
+            ]
+            _ = gains[min(user_membership_sudo.quiz_attempts_count, len(gains)) - 1]
+            # No karma update on purpose
+
+        return True
+
+    def _compute_quiz_info(self, target_partner, quiz_done=False):  # type: ignore[override]
+        """Remove karma amounts from quiz info structures."""
+        result = super()._compute_quiz_info(target_partner, quiz_done)
+        if not result:
+            return result
+        for values in result.values():
+            if isinstance(values, dict):
+                values.update({
+                    'quiz_karma_max': 0,
+                    'quiz_karma_gain': 0,
+                    'quiz_karma_won': 0,
+                })
+        return result
+
+    def _action_vote(self, vote, upvote=True):  # type: ignore[override]
+        """Keep voting functional but do not add karma when liking slides."""
+        result = super()._action_vote(vote, upvote=upvote)
+        return result

--- a/elearning_no_gamification/models/slide_slide_partner.py
+++ b/elearning_no_gamification/models/slide_slide_partner.py
@@ -1,0 +1,12 @@
+"""Ensure slide partner records never adjust karma."""
+
+from odoo import models
+
+from .no_karma_mixin import NoKarmaMixin
+
+
+class SlideSlidePartner(NoKarmaMixin, models.Model):
+    _inherit = "slide.slide.partner"
+
+    def _update_karma(self, *args, **kwargs):  # type: ignore[override]
+        return self._suppress_karma(*args, **kwargs)

--- a/elearning_no_gamification/models/survey_user_input.py
+++ b/elearning_no_gamification/models/survey_user_input.py
@@ -1,0 +1,12 @@
+"""Ensure survey hooks never reward karma."""
+
+from odoo import models
+
+from .no_karma_mixin import NoKarmaMixin
+
+
+class SurveyUserInput(NoKarmaMixin, models.Model):
+    _inherit = "survey.user_input"
+
+    def _reward_karma(self, *args, **kwargs):  # type: ignore[override]
+        return self._suppress_karma(*args, **kwargs)

--- a/elearning_no_gamification/security/ir.model.access.csv
+++ b/elearning_no_gamification/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/elearning_no_gamification/static/src/scss/no_karma.scss
+++ b/elearning_no_gamification/static/src/scss/no_karma.scss
@@ -1,0 +1,32 @@
+/* Frontend overrides to hide karma related UI. */
+.o_wslides_js_course_karma,
+.o_wslides_js_slide_karma,
+.o_wslides_karma_badges,
+.o_wslides_karma_leaderboard,
+.o_wslides_karma_box,
+.o_wslides_karma_progress,
+.o_wslides_karma_rank,
+.o_wslides_js_course_rank,
+.o_wslides_js_course_karma_gain,
+.o_wslides_course_awards,
+.o_wslides_course_karma,
+.o_wslides_slide_karma,
+.o_wslides_sidebar_badges,
+.o_wslides_leaderboard,
+.o_wslides_js_profile_karma,
+.o_wslides_js_karmaboard,
+.o_wslides_js_member_karma,
+.o_wslides_js_like_score,
+.o_wslides_js_karma_counter,
+.o_wslides_course_top .o_wslides_crowns,
+.o_survey_karma_notification,
+.o_survey_karma_badge {
+    display: none !important;
+}
+
+/* Backend hide karma fields and badges. */
+.o_form_view [data-name*="karma"],
+.o_form_view .o_field_widget[name*="karma"],
+.o_form_view .o_field_widget[name*="karma"] ~ .o_form_label {
+    display: none !important;
+}

--- a/elearning_no_gamification/views/assets.xml
+++ b/elearning_no_gamification/views/assets.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <data>
+        <template id="assets_frontend" inherit_id="website_slides.assets_frontend" name="Disable eLearning karma frontend">
+            <xpath expr="." position="inside">
+                <link rel="stylesheet" type="text/scss" href="/elearning_no_gamification/static/src/scss/no_karma.scss"/>
+            </xpath>
+        </template>
+        <template id="assets_backend" inherit_id="web.assets_backend" name="Disable eLearning karma backend">
+            <xpath expr="." position="inside">
+                <link rel="stylesheet" type="text/scss" href="/elearning_no_gamification/static/src/scss/no_karma.scss"/>
+            </xpath>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
## Summary
- add a dedicated `elearning_no_gamification` addon that depends on eLearning and survey
- override karma-related hooks to neutralise point awards and action gating while keeping other behaviour intact
- inject frontend and backend assets to hide karma counters, badges, and leaderboards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7dd5d553c8321a4494b16cb404967